### PR TITLE
feat : 테스트 파일에서 path alias를 인식할 수 있도록 변경

### DIFF
--- a/packages/backend/jest.config.json
+++ b/packages/backend/jest.config.json
@@ -1,0 +1,20 @@
+{
+  "moduleFileExtensions": [
+    "js",
+    "json",
+    "ts"
+  ],
+  "rootDir": "src",
+  "testRegex": ".*\\.spec\\.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "collectCoverageFrom": [
+    "**/*.(t|j)s"
+  ],
+  "coverageDirectory": "../coverage",
+  "testEnvironment": "node",
+  "moduleNameMapper": {
+    "~/(.*)": "<rootDir>/$1"
+  }
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -49,22 +49,5 @@
     "ts-node": "^10.0.0",
     "tsconfig-paths": "4.2.0",
     "typescript": "^4.7.4"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/packages/backend/src/app.controller.spec.ts
+++ b/packages/backend/src/app.controller.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { AppController } from '~/app.controller';
+import { AppService } from '~/app.service';
 
 describe('AppController', () => {
   let appController: AppController;
@@ -16,7 +16,7 @@ describe('AppController', () => {
 
   describe('root', () => {
     it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+      expect(appController.getHello()).toBe('Hello, World!');
     });
   });
 });

--- a/packages/frontend/src/App.test.tsx
+++ b/packages/frontend/src/App.test.tsx
@@ -1,4 +1,4 @@
-import App from "./App";
+import App from "~/App";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from "vitest/config";
+import { resolve } from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  resolve: {
+    alias: [{ find: "~", replacement: resolve(__dirname, "src") }],
+  },
   test: {
     globals: true,
     environment: "happy-dom",


### PR DESCRIPTION
DESC
----
- 코드에 path alias를 사용한 경우 테스트 파일에서 에러가 발생하던 오류를 해결
- 테스트 코드에서 path alias를 이용해 테스트할 코드를 가져올 수 있도록 변경 NOTE
----
vitest 테스트 코드의 경우 IDE상에선 오류가 발생하나 실행 결과 오류가 발생하지 않음