### PR TITLE
fix : backend와 common의 연결성 강화

### DIFF
--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "allowJs": true,
     "baseUrl": "./",
     "declaration": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
DESC
----
common은 cjs 형식으로 컴파일되면서 자바스크립트로 변경됨
그런데 backend는 allowJs 설정이 명시되지 않아 의도치 않은 오류가 생길 수 있음 따라서 backend의 allowJs를 true로 명시해 혹시 모를 오류를 미연에 방지