### PR TITLE
fix : backend의 ts-laoder에서 사용할 webpack 버전 지정

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -9646,13 +9646,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["micromatch", "npm:4.0.5"],\
             ["semver", "npm:7.4.0"],\
             ["typescript", "patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"],\
-            ["webpack", null]\
+            ["webpack", "virtual:36f30c0e0880d1a5bcbdb27123a60116da2c587050e9ebe8157ec03ed5aff1bd1259052c21bca582aedd8340ce5ff1d629cc4934d11d3824d4ee220cf57685ae#npm:5.79.0"]\
           ],\
           "packagePeers": [\
             "@types/typescript",\
             "@types/webpack",\
-            "typescript",\
-            "webpack"\
+            "typescript"\
           ],\
           "linkType": "HARD"\
         }]\

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,3 +4,7 @@ packageExtensions:
   "local-pkg@*": # This is required for vitest as it accesses happy-dom through local-pkg on its behalf
     dependencies:
       "happy-dom": "*"
+
+  "ts-loader@*":
+    dependencies:
+      "webpack": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8336,7 +8336,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.79.0":
+"webpack@npm:*, webpack@npm:5.79.0":
   version: 5.79.0
   resolution: "webpack@npm:5.79.0"
   dependencies:


### PR DESCRIPTION
DESC
----
nestjs에서 사용하는 ts-loader가 내부적으로 webpack의 버전을 지정해주지 않으므로

ts-loader에서 사용할 webpack의 버전을 임시로 지정해 의도치 않은 오류를 방지