### PR TITLE
feat : frontend에서 환경 변수 값을 활용

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -3,11 +3,14 @@ import { useState } from 'react';
 import '~/App.css';
 import reactLogo from '~/assets/react.svg';
 import viteLogo from '~/assets/vite.svg';
+import env from '~/env';
 
 function App() {
   const [count, setCount] = useState(0);
 
   console.log(hello());
+
+  console.log(env);
 
   return (
     <div className="App">

--- a/packages/frontend/src/env/index.ts
+++ b/packages/frontend/src/env/index.ts
@@ -1,0 +1,2 @@
+import removePrefix from './removePrefix';
+export default removePrefix(import.meta.env);

--- a/packages/frontend/src/env/removePrefix.test.ts
+++ b/packages/frontend/src/env/removePrefix.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import removePrefix from './removePrefix';
+
+describe('Removing env prefix', () => {
+  let testEnv: any;
+
+  beforeEach(() => {
+    testEnv = {
+      VITE_FE_PORT: '5173',
+    };
+  });
+
+  it('should work', () => {
+    const prefixRemovedEnd = removePrefix(testEnv);
+    expect(prefixRemovedEnd).toEqual({ FE_PORT: testEnv.VITE_FE_PORT });
+  });
+
+  it('should ignore key without prefix', () => {
+    testEnv.FE_PORT = testEnv.VITE_FE_PORT;
+    const prefixRemovedEnd = removePrefix(testEnv);
+    expect(prefixRemovedEnd).toEqual({ FE_PORT: testEnv.VITE_FE_PORT });
+  });
+
+  it('should ignore empty value', () => {
+    testEnv.VITE_FE_PORT = '';
+    const prefixRemovedEnd = removePrefix(testEnv);
+    expect(prefixRemovedEnd).toEqual({});
+  });
+});

--- a/packages/frontend/src/env/removePrefix.ts
+++ b/packages/frontend/src/env/removePrefix.ts
@@ -1,0 +1,18 @@
+const PREFIX = 'VITE_';
+
+const ifKeyHasPrefix = (key: string) => key.indexOf(PREFIX) === 0;
+const removeKeyPrefix = (key: string) => key.substring(PREFIX.length);
+
+const removePrefix = (env: NodeJS.ProcessEnv) =>
+  Object.keys(env)
+    .filter(ifKeyHasPrefix)
+    .filter((key) => env[key])
+    .reduce(
+      (acc, key) => ({
+        ...acc,
+        [removeKeyPrefix(key)]: env[key],
+      }),
+      {} as NodeJS.ProcessEnv,
+    );
+
+export default removePrefix;

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
   },
+  envDir: resolve(__dirname, '..', '..'),
   resolve: {
     alias: [{ find: '~', replacement: resolve(__dirname, 'src') }],
   },


### PR DESCRIPTION
DESC
----
- vite에서 제공하는 기본 기능을 이용해 .env 파일을 환경 변수로 설정
- prefix를 제거하면서 실제로 사용할 환경 변수만 별개 object에 저장

NOTE
----
.env validation은 구현되지 않음