### PR TITLE
feat : frontend 환경 변수에서 prefix 제거

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,18 +1,21 @@
 {
-  "search.exclude": {
-    "**/.yarn": true,
-    "**/.pnp.*": true
-  },
-  "typescript.tsdk": ".yarn/sdks/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
-
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true,
-    "soruce.fixAll.eslint": true
+    "soruce.fixAll.eslint": true,
+    "source.organizeImports": true
   },
   "editor.formatOnSave": true,
-
-  "eslint.workingDirectories": [{ "mode": "auto" }],
   "eslint.packageManager": "yarn",
-  "eslint.probe": ["typescript", "typescriptreact", "html", "markdown"]
+  "eslint.probe": ["typescript", "typescriptreact", "html", "markdown"],
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ],
+  "search.exclude": {
+    "**/.pnp.*": true,
+    "**/.yarn": true
+  },
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "typescript.tsdk": ".yarn/sdks/typescript/lib"
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -3,11 +3,13 @@ import { useState } from 'react';
 import '~/App.css';
 import reactLogo from '~/assets/react.svg';
 import viteLogo from '~/assets/vite.svg';
+import env from '~/env';
 
 function App() {
   const [count, setCount] = useState(0);
 
   console.log(hello());
+  console.log(env);
 
   return (
     <div className="App">

--- a/packages/frontend/src/env/index.ts
+++ b/packages/frontend/src/env/index.ts
@@ -1,0 +1,2 @@
+import removePrefix from './removePrefix';
+export default removePrefix(import.meta.env);

--- a/packages/frontend/src/env/removePrefix.test.ts
+++ b/packages/frontend/src/env/removePrefix.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import removePrefix from '~/env/removePrefix';
+
+describe('removePrefix', () => {
+  let processEnv: NodeJS.ProcessEnv;
+  const toEqualEnv: NodeJS.ProcessEnv = {
+    BE_PORT: '3000',
+    FE_PORT: '5173',
+  };
+
+  beforeEach(() => {
+    processEnv = {
+      VITE_BE_PORT: '3000',
+      VITE_FE_PORT: '5173',
+    };
+  });
+
+  it('should work', () => {
+    const env = removePrefix(processEnv);
+    expect(env).toEqual(toEqualEnv);
+  });
+
+  it('should ignore env without prefix', () => {
+    processEnv.IGNORED = 'asdasd';
+    const env = removePrefix(processEnv);
+    expect(env).toEqual(toEqualEnv);
+  });
+
+  it('should ignore empty env', () => {
+    processEnv.VITE_EMPTY_ENV = '';
+    const env = removePrefix(processEnv);
+    expect(env).toEqual(toEqualEnv);
+  });
+});

--- a/packages/frontend/src/env/removePrefix.ts
+++ b/packages/frontend/src/env/removePrefix.ts
@@ -1,0 +1,12 @@
+const PREFIX = 'VITE_';
+
+const ifKeyHasPrefix = (key: string) => key.startsWith(PREFIX);
+const removeKeyPrefix = (key: string) => key.replace(PREFIX, '');
+
+const removePrefix = (env: NodeJS.ProcessEnv) =>
+  Object.keys(env)
+    .filter(ifKeyHasPrefix)
+    .filter((key) => env[key])
+    .reduce((acc, key) => ({ ...acc, [removeKeyPrefix(key)]: env[key] }), {} as NodeJS.ProcessEnv);
+
+export default removePrefix;


### PR DESCRIPTION
DESC
----
- frontend에서 사용하는 환경 변수의 prefix를 제거

TEST
----
1. 환경 변수 중 `VITE_` prefix가 붙은 필드를 추가
2. 해당 환경 변수가 `~/env`에서 prefix가 제거된 채로 존재하는지 확인