### PR TITLE
fix : drizzle 설정 파일을 백엔드 build 대상에서 제거

### DIFF
--- a/packages/backend/tsconfig.build.json
+++ b/packages/backend/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "drizzle.config.ts"]
 }


### PR DESCRIPTION
DESC
----
- 백엔드 ORM 설정 파일인 `drizzle.config.ts`는 `<rootDir>`보다 상위 디렉토리에 있음
- 따라서 `@nestjs/cli`가 build할 때 `drizzle.config.ts`를 함께 build하며 `dist` 디렉토리의 구조가 무너짐
- `drizzle.config.ts`를 build 대상에서 제외해 문제를 해결함

TEST
----
1. `yarn backend build` 커맨드 실행
2. 백엔드의 `dist` 디렉토리 안에 `drizzle.config.js` 파일이 존재하지 않는지 확인
3. 백엔드의 `dist` 디렉토리 안에 `src` 디렉토리가 존재하지 않는지 확인
4. 백엔드의 `dist` 디렉토리 안에 `main.js` 파일이 존재하는지 확인