### PR TITLE
chore : host rule에 docker host 추가

### DIFF
--- a/packages/common/src/zod/host.test.ts
+++ b/packages/common/src/zod/host.test.ts
@@ -16,6 +16,10 @@ describe('host', () => {
     it('localhost', () => {
       expect(() => HOST_RULE.parse('localhost')).not.throw();
     });
+
+    it('docker host', () => {
+      expect(() => HOST_RULE.parse('host.docker.internal')).not.throw();
+    });
   });
 
   describe('should throw error when', () => {

--- a/packages/common/src/zod/host.ts
+++ b/packages/common/src/zod/host.ts
@@ -1,10 +1,11 @@
 import { ZodIssueCode, z } from 'zod';
 
-const HOST_RULE = z.union([
-  z
-    .string()
-    .ip()
-    .refine((ip) => ip.split('.')[0] !== '0', ZodIssueCode.invalid_string),
-  z.literal('localhost'),
-]);
+const IP_RULE = z
+  .string()
+  .ip()
+  .refine((ip) => ip.split('.')[0] !== '0', ZodIssueCode.invalid_string);
+const LOCALHOST_RULE = z.literal('localhost');
+const DOCKERHOST_RULE = z.literal('host.docker.internal');
+
+const HOST_RULE = z.union([IP_RULE, LOCALHOST_RULE, DOCKERHOST_RULE]);
 export default HOST_RULE;


### PR DESCRIPTION
DESC
----
- Production 레벨에서 사용할 host인 `host.docker.internal`을 host rule에 추가