### PR TITLE
feat : fetch에 사용되는 기본적인 기능을 함수로 묶음

### DIFF
--- a/packages/frontend/src/api/fetchCore.test.ts
+++ b/packages/frontend/src/api/fetchCore.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect } from 'vitest';
+import fetchCore from '~/api/fetchCore';
+import { BE_ORIGIN } from '~/constants';
+import { server } from '~/mock';
+
+describe('fetchCore', () => {
+  beforeAll(() => server.listen());
+  // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
+  beforeEach(() => location.replace(BE_ORIGIN));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  it('shold work', async () => {
+    const result = await fetchCore('/');
+    expect(result).toStrictEqual({ foo: 'bar' });
+  });
+
+  describe('should throw error when', () => {
+    it('invalid path', () => {
+      const path = '/invalid/path';
+      expect(async () => fetchCore(`${BE_ORIGIN}${path}`)).rejects.toThrow();
+    });
+
+    it('invalid method', () => {
+      const path = '/';
+      expect(async () =>
+        fetchCore(`${BE_ORIGIN}${path}`, { method: 'WRONG_METHOD' }),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/packages/frontend/src/api/fetchCore.ts
+++ b/packages/frontend/src/api/fetchCore.ts
@@ -1,0 +1,20 @@
+import { mergeObjects } from '@my-task/common';
+import { BE_ORIGIN, DEFAULT_FETCH_OPTION } from '~/constants';
+
+const getBody = (option: RequestInit) => {
+  const body = option.body && JSON.stringify(option.body);
+  delete option.body;
+  return body;
+};
+
+const fetchCore = async (path: string, option: RequestInit = {}) => {
+  const body = getBody(option);
+  const url = new URL(path, BE_ORIGIN);
+
+  option = { ...mergeObjects(option, DEFAULT_FETCH_OPTION), body } as RequestInit;
+
+  const res = await fetch(url.href, option);
+  return res.json();
+};
+
+export default fetchCore;


### PR DESCRIPTION
DESC
----
- fetch할 origin을 `BE_ORIGIN`으로 고정
- fetch할 위치를 URL 객체로 wrap
- fetch의 body를 자동으로 stringify
- fetch의 기본 설정을 자동으로 가져와 사용
- fetch의 결과를 자동으로 json으로 변환

NOTE
----
- fetchCore는 직접 가져와 사용하지 않으므로 barrel import를 사용하지 않음