### PR TITLE
fix : fetchCore에서 어떤 형태의 body든 받을 수 있도록 설정

### DIFF
--- a/packages/frontend/src/api/fetchCore.test.ts
+++ b/packages/frontend/src/api/fetchCore.test.ts
@@ -10,9 +10,17 @@ describe('fetchCore', () => {
   afterEach(() => server.resetHandlers());
   afterAll(() => server.close());
 
-  it('shold work', async () => {
-    const result = await fetchCore('/');
-    expect(result).toStrictEqual({ foo: 'bar' });
+  describe('should work with', () => {
+    it('no body', async () => {
+      const result = await fetchCore('/');
+      expect(result).toStrictEqual({ foo: 'bar' });
+    });
+
+    it('body', async () => {
+      const body = { date: new Date().getTime() };
+      const result = await fetchCore('/', { method: 'POST', body });
+      expect(result).toStrictEqual(body);
+    });
   });
 
   describe('should throw error when', () => {

--- a/packages/frontend/src/api/fetchCore.ts
+++ b/packages/frontend/src/api/fetchCore.ts
@@ -1,19 +1,23 @@
 import { mergeObjects } from '@my-task/common';
 import { BE_ORIGIN, DEFAULT_FETCH_OPTION } from '~/constants';
 
-const getBody = (option: RequestInit) => {
+type RequestOption = Omit<RequestInit, 'body'> & {
+  body?: { [key: string]: any };
+};
+
+const getBody = (option: RequestOption) => {
   const body = option.body && JSON.stringify(option.body);
   delete option.body;
   return body;
 };
 
-const fetchCore = async (path: string, option: RequestInit = {}) => {
+const fetchCore = async (path: string, option: RequestOption = {}) => {
   const body = getBody(option);
   const url = new URL(path, BE_ORIGIN);
 
-  option = { ...mergeObjects(option, DEFAULT_FETCH_OPTION), body } as RequestInit;
+  const fetchOption = { ...mergeObjects(option, DEFAULT_FETCH_OPTION), body } as RequestInit;
 
-  const res = await fetch(url.href, option);
+  const res = await fetch(url.href, fetchOption);
   return res.json();
 };
 

--- a/packages/frontend/src/mock/handlers.ts
+++ b/packages/frontend/src/mock/handlers.ts
@@ -3,4 +3,8 @@ import { BE_ORIGIN } from '~/constants';
 
 export const handlers = [
   rest.get(`${BE_ORIGIN}/`, (_, res, ctx) => res(ctx.status(200), ctx.json({ foo: 'bar' }))),
+  rest.post(`${BE_ORIGIN}/`, async (req, res, ctx) => {
+    const body = await req.json();
+    return res(ctx.status(200), ctx.json(body));
+  }),
 ];


### PR DESCRIPTION
DESC
----
- 기존 fetchCore는 `RequestInit`을 그대로 사용하였기 때문에 body 값으로 json 객체를 넣어줄 경우 오류 발생
- fetchCore의 option 인자의 타입을 수정해 body값으로 json 객체를 넣어줄 수 있도록 수정

NOTE
----
- fetchCore에서 사용하는 getBody가 순수함수가 아닌 것은 의도된 사항