### PR TITLE
fix : 서버에서 throw된 경우 fetchCore에서도 throw

### DIFF
--- a/packages/frontend/src/api/fetchCore.test.ts
+++ b/packages/frontend/src/api/fetchCore.test.ts
@@ -4,7 +4,7 @@ import { BE_ORIGIN } from '~/constants';
 import { server } from '~/mock';
 
 describe('fetchCore', () => {
-  beforeAll(() => server.listen());
+  beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
   // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
   beforeEach(() => location.replace(BE_ORIGIN));
   afterEach(() => server.resetHandlers());
@@ -26,14 +26,17 @@ describe('fetchCore', () => {
   describe('should throw error when', () => {
     it('invalid path', () => {
       const path = '/invalid/path';
-      expect(async () => fetchCore(`${BE_ORIGIN}${path}`)).rejects.toThrow();
+      expect(async () => fetchCore(path)).rejects.toThrow();
     });
 
     it('invalid method', () => {
       const path = '/';
-      expect(async () =>
-        fetchCore(`${BE_ORIGIN}${path}`, { method: 'WRONG_METHOD' }),
-      ).rejects.toThrow();
+      expect(async () => fetchCore(path, { method: 'WRONG_METHOD' })).rejects.toThrow();
+    });
+
+    it('error thrown in server', () => {
+      const path = '/error';
+      expect(async () => fetchCore(path)).rejects.toThrow();
     });
   });
 });

--- a/packages/frontend/src/api/fetchCore.ts
+++ b/packages/frontend/src/api/fetchCore.ts
@@ -18,6 +18,7 @@ const fetchCore = async (path: string, option: RequestOption = {}) => {
   const fetchOption = { ...mergeObjects(option, DEFAULT_FETCH_OPTION), body } as RequestInit;
 
   const res = await fetch(url.href, fetchOption);
+  if (!res.ok) throw { ...(await res.json()), status: res.status };
   return res.json();
 };
 


### PR DESCRIPTION
DESC
----
- 기존의 fetchCore는 서버에서 Error가 발생했을 때 Error 객체를 그대로 json화하여 정상적인 응답인 것처럼 반환
- `res.ok`를 이용해 서버의 응답이 정상 응답인지 확인한 뒤, 만일 아니라면 status를 포함시킨 뒤 throw