### PR TITLE
feat : auth service에 db 접근 기능을 생성

### DIFF
--- a/packages/backend/src/modules/auth/auth.module.ts
+++ b/packages/backend/src/modules/auth/auth.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
-import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
 
 @Module({
   providers: [AuthService],
-  controllers: [AuthController]
+  controllers: [AuthController],
 })
 export class AuthModule {}

--- a/packages/backend/src/modules/auth/auth.service.spec.ts
+++ b/packages/backend/src/modules/auth/auth.service.spec.ts
@@ -1,13 +1,26 @@
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { DatabaseProvider } from '~/modules/database/database.provider';
+import { DatabaseService } from '~/modules/database/database.service';
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+    const databaseModule: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forFeature(() => process.env)],
+      providers: [DatabaseService, DatabaseProvider],
     }).compile();
+
+    const databaseService = databaseModule.get<DatabaseService>(DatabaseService);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DatabaseService, AuthService],
+    })
+      .overrideProvider(DatabaseService)
+      .useValue(databaseService)
+      .compile();
 
     service = module.get<AuthService>(AuthService);
   });

--- a/packages/backend/src/modules/auth/auth.service.ts
+++ b/packages/backend/src/modules/auth/auth.service.ts
@@ -1,4 +1,15 @@
 import { Injectable } from '@nestjs/common';
+import { DatabaseService } from '~/modules/database/database.service';
+import { users } from '~/modules/database/schema';
 
 @Injectable()
-export class AuthService {}
+export class AuthService {
+  private readonly db;
+  constructor(databaseService: DatabaseService) {
+    this.db = databaseService.db;
+  }
+
+  readAll() {
+    return this.db.select().from(users).execute();
+  }
+}

--- a/packages/backend/src/modules/database/database.module.ts
+++ b/packages/backend/src/modules/database/database.module.ts
@@ -1,8 +1,10 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { DatabaseProvider } from '~/modules/database/database.provider';
 import { DatabaseService } from '~/modules/database/database.service';
 
+@Global()
 @Module({
   providers: [DatabaseProvider, DatabaseService],
+  exports: [DatabaseService],
 })
 export class DatabaseModule {}


### PR DESCRIPTION
DESC
----
- AuthService에 DatabaseService를 주입하여 DB에 접근이 가능하도록 설정

NOTE
----
- 다른 모듈에서 바로 접근시키기 위해 DatabaseModule을 Global로 설정
- 기존 DatabaseModule에서 DatabaseService가 export되어있지 않아 현재 커밋에서 export함
- databaseService의 역할은 drizzleOrm을 nestjs에 입력시키는 것이므로 databaseService 자체는 사용하지 않음

#75 