### PR TITLE
feat :

### DIFF
--- a/packages/common/src/zod/index.ts
+++ b/packages/common/src/zod/index.ts
@@ -1,2 +1,5 @@
+import parseWithZod from './parseWithZod';
+
 export * from './dto';
 export * from './env';
+export { parseWithZod };

--- a/packages/common/src/zod/parseWithZod.test.ts
+++ b/packages/common/src/zod/parseWithZod.test.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { describe } from 'mocha';
+import { z } from 'zod';
+import parseWithZod from './parseWithZod';
+
+describe('parseWithZod', () => {
+  describe('should return data with', () => {
+    it('simple schema', () => {
+      const test = 'test';
+      const zodStringSchema = z.string();
+      const result = parseWithZod(test, zodStringSchema);
+      expect(result).deep.equal({ success: true, data: test });
+    });
+
+    it('transformed schema', () => {
+      const test = 123;
+      const zodNumericStringSchema = z.number().transform(String);
+      const result = parseWithZod(test, zodNumericStringSchema);
+
+      expect(result.success).true;
+      expect(result.data).equal(test.toString());
+      expect(result.error).undefined;
+    });
+  });
+
+  describe('should return error with', () => {
+    it('invalid type', () => {
+      const test = 123;
+      const zodStringSchema = z.string();
+      const result = parseWithZod(test, zodStringSchema);
+      expect(result.success).false;
+      expect(result.data).undefined;
+      expect(result.error).not.undefined;
+    });
+
+    it('invalid string', () => {
+      const test = 'invalid@string';
+      const zodEmailSchema = z.string().email();
+      const result = parseWithZod(test, zodEmailSchema);
+      expect(result.success).false;
+      expect(result.data).undefined;
+      expect(result.error).not.undefined;
+    });
+  });
+});

--- a/packages/common/src/zod/parseWithZod.ts
+++ b/packages/common/src/zod/parseWithZod.ts
@@ -1,0 +1,10 @@
+import { ZodError, ZodType } from 'zod';
+
+const parseWithZod = <Output, Input = any>(data: any, zodSchema: ZodType<Output, any, Input>) =>
+  zodSchema.safeParse(data) as {
+    success: boolean;
+    data?: ReturnType<(typeof zodSchema)['parse']>;
+    error?: ZodError;
+  };
+
+export default parseWithZod;

--- a/packages/frontend/src/mock/handlers.ts
+++ b/packages/frontend/src/mock/handlers.ts
@@ -1,4 +1,4 @@
-import { createUserDTO } from '@my-task/common';
+import { createUserDTO, parseWithZod } from '@my-task/common';
 import { rest } from 'msw';
 import { BE_ORIGIN } from '~/constants';
 
@@ -19,12 +19,11 @@ export const handlers = [
 
     ctx.delay();
 
-    try {
-      const dto = createUserDTO.parse(body);
-      const id = Math.floor(Math.random() * 10);
-      return res(ctx.status(200), ctx.json({ ...dto, id }));
-    } catch (error) {
-      return res(ctx.status(400), ctx.json({ errorMessage: 'Wrong DTO: try again!' }));
-    }
+    const { data, error } = parseWithZod(body, createUserDTO);
+
+    if (error) return res(ctx.status(400), ctx.json({ errorMessage: 'Wrong DTO: try again!' }));
+
+    const id = Math.floor(Math.random() * 10);
+    return res(ctx.status(200), ctx.json({ ...data, id }));
   }),
 ];


### PR DESCRIPTION
DESC
----
- zod의 safeParse는 `success` 필드만 반드시 등장하고, `data` 혹은 `error` 필드는 타입스크립트 상 접근할 수 없음
- parseWithZod 함수를 이용해 세 필드 모두 접근 가능하도록 설정