### PR TITLE
chore : model 종류를 backend에서 common으로 이동

### DIFF
--- a/packages/common/src/database/index.ts
+++ b/packages/common/src/database/index.ts
@@ -1,1 +1,2 @@
+export * from './model';
 export * from './schema';

--- a/packages/common/src/database/model/index.ts
+++ b/packages/common/src/database/model/index.ts
@@ -1,2 +1,2 @@
 import User from './user.model';
-export { User };
+export type { User };

--- a/packages/common/src/database/model/user.model.ts
+++ b/packages/common/src/database/model/user.model.ts
@@ -1,5 +1,5 @@
-import { users } from '@my-task/common';
 import { InferModel } from 'drizzle-orm';
+import { users } from '../schema';
 
 type User = InferModel<typeof users>;
 

--- a/packages/frontend/src/routes/Join/index.tsx
+++ b/packages/frontend/src/routes/Join/index.tsx
@@ -1,3 +1,4 @@
+import { User } from '@my-task/common';
 import { FormEventHandler, useRef, useState } from 'react';
 import { postJoin } from '~/api';
 import './index.css';
@@ -6,8 +7,7 @@ const Join = () => {
   const [statusText, setStatusText] = useState('');
   const emailInputRef = useRef<HTMLInputElement>(null);
   const joinMutation = postJoin({
-    onSuccess: (data: { email: string }) =>
-      setStatusText(`User(${data.email}) has successfully joined!`),
+    onSuccess: (data: User) => setStatusText(`User(${data.email}) has successfully joined!`),
     onError: (err: { errorMessage: string; status: number }) => setStatusText(err.errorMessage),
   });
 


### PR DESCRIPTION
DESC
----
- Model 타입을 프론트엔드에서도 사용할 수 있도록 backend에서 common으로 이동