### PR TITLE
feat : fetchCore의 body에 허용할 타입을 지정할 수 있도록 설정

### DIFF
--- a/packages/frontend/src/api/fetchCore.ts
+++ b/packages/frontend/src/api/fetchCore.ts
@@ -1,13 +1,19 @@
 import { mergeObjects } from '@my-task/common';
 import { BE_ORIGIN, DEFAULT_FETCH_OPTION } from '~/constants';
 
-type RequestOption = Omit<RequestInit, 'body'> & {
-  body?: { [key: string]: any };
+type BasicBodyType = { [key: string]: any };
+
+type RequestOption<BodyType extends BasicBodyType> = Omit<RequestInit, 'body'> & {
+  body?: BodyType;
 };
 
-const getBody = ({ body }: RequestOption) => body && JSON.stringify(body);
+const getBody = <Input extends BasicBodyType>({ body }: RequestOption<Input>) =>
+  body && JSON.stringify(body);
 
-const fetchCore = async <Output = any>(path: string, option: RequestOption = {}) => {
+const fetchCore = async <Output = any, Input extends BasicBodyType = BasicBodyType>(
+  path: string,
+  option: RequestOption<Input> = {},
+) => {
   const body = getBody(option);
   const url = new URL(path, BE_ORIGIN);
 


### PR DESCRIPTION
DESC
----
- fetchCore에서 body에 허용할 타입을 제네릭을 이용해 지정할 수 있도록 설정

NOTE
----
- IDE 상에서는 error를 표시하지만 실제로는 exception을 발생시키지 않고 작동함