### PR TITLE
refact : json 객체 타입 정의

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -2,6 +2,7 @@ import * as schema from './database/schema';
 
 export * from './database';
 export * from './hello';
+export * from './types';
 export * from './utils';
 export * from './zod';
 export { schema };

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -1,0 +1,2 @@
+import JsonObject from './jsonObject';
+export type { JsonObject };

--- a/packages/common/src/types/jsonObject.ts
+++ b/packages/common/src/types/jsonObject.ts
@@ -1,0 +1,5 @@
+type JsonObject = {
+  [key: string]: string | number | boolean | JsonObject;
+};
+
+export default JsonObject;

--- a/packages/common/src/utils/mergeObjects.test.ts
+++ b/packages/common/src/utils/mergeObjects.test.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
+import { JsonObject } from 'src/types';
 import mergeObjects from './mergeObjects';
 
 describe('mergeObjects', () => {
-  let obj1: object, obj2: object;
+  let obj1: JsonObject, obj2: JsonObject;
 
   beforeEach(() => {
     obj1 = { a: 1, b: 2 };

--- a/packages/common/src/utils/mergeObjects.ts
+++ b/packages/common/src/utils/mergeObjects.ts
@@ -1,20 +1,20 @@
-type ObjectType = { [key: string]: any };
+import { JsonObject } from 'src/types';
 
 const isObject = (item: any) => typeof item === 'object';
 
-const mergeObjects = (...objects: ObjectType[]): ObjectType =>
+const mergeObjects = (...objects: JsonObject[]): JsonObject =>
   objects.reverse().reduce(
     (mergedObject, currentObject) =>
       Object.keys(currentObject).reduce((object, key) => {
         const isBothValObject = isObject(mergedObject[key]) && isObject(currentObject[key]);
 
         const value = isBothValObject
-          ? mergeObjects(currentObject[key], mergedObject[key])
+          ? mergeObjects(currentObject[key] as JsonObject, mergedObject[key] as JsonObject)
           : currentObject[key];
 
         return { ...object, [key]: value };
       }, structuredClone(mergedObject)),
-    {} as ObjectType,
+    {} as JsonObject,
   );
 
 export default mergeObjects;

--- a/packages/common/src/zod/dto/auth/createUser.test.ts
+++ b/packages/common/src/zod/dto/auth/createUser.test.ts
@@ -1,10 +1,11 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
+import { JsonObject } from 'src/types';
 import { ZodIssueCode } from 'zod';
 import { createUserDTO, CreateUserDTO } from './createUser';
 
 describe('createUserDTO', () => {
-  let dto: { [key: string]: any };
+  let dto: JsonObject;
 
   beforeEach(() => {
     dto = { email: 'testing@example.com' };
@@ -40,7 +41,7 @@ describe('createUserDTO', () => {
 });
 
 describe('CreateUserDTO', () => {
-  let dto: { [key: string]: any };
+  let dto: JsonObject;
 
   beforeEach(() => {
     dto = { email: 'testing@example.com' };

--- a/packages/frontend/src/api/fetchCore.ts
+++ b/packages/frontend/src/api/fetchCore.ts
@@ -1,16 +1,14 @@
-import { mergeObjects } from '@my-task/common';
+import { JsonObject, mergeObjects } from '@my-task/common';
 import { BE_ORIGIN, DEFAULT_FETCH_OPTION } from '~/constants';
 
-type BasicBodyType = { [key: string]: any };
-
-type RequestOption<BodyType extends BasicBodyType> = Omit<RequestInit, 'body'> & {
+type RequestOption<BodyType extends JsonObject> = Omit<RequestInit, 'body'> & {
   body?: BodyType;
 };
 
-const getBody = <Input extends BasicBodyType>({ body }: RequestOption<Input>) =>
+const getBody = <Input extends JsonObject>({ body }: RequestOption<Input>) =>
   body && JSON.stringify(body);
 
-const fetchCore = async <Output = any, Input extends BasicBodyType = BasicBodyType>(
+const fetchCore = async <Output = any, Input extends JsonObject = JsonObject>(
   path: string,
   option: RequestOption<Input> = {},
 ) => {


### PR DESCRIPTION
DESC
----
- 여러 기능 및 테스트에서 임시로 정의해 사용하던 JSON 객체 타입을 common에 정의

NOTE
----
- 객체의 value값 중 null 혹은 undefined는 포함하지 않음