### PR TITLE
chore : common 패키지에 path alias 적용

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2099,6 +2099,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["drizzle-orm", "virtual:a16ae7f139ed3027b91dedc7271f0dba1d11ff76ae1acdf45c56d603088952facf7a0dd6438de36245f734e7f1860aee3e0a3834922f39b79cdbecb14afe37da#npm:0.27.0"],\
             ["eslint-plugin-import", "virtual:ec460f7b9669e9526be8d95ae865879fa75c18cc6dd56e9b411673f447efcb78b543355086075a52c7ac25d888e2171e528ed008b24aaf36bb94fbde779182d8#npm:2.27.5"],\
             ["mocha", "npm:10.2.0"],\
+            ["tsconfig-paths", "npm:4.2.0"],\
             ["typescript", "patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"],\
             ["zod", "npm:3.21.4"]\
           ],\

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -21,6 +21,7 @@
     "drizzle-orm": "^0.27.0",
     "eslint-plugin-import": "^2.27.5",
     "mocha": "^10.2.0",
+    "tsconfig-paths": "4.2.0",
     "typescript": "^5.0.4"
   },
   "scripts": {

--- a/packages/common/src/database/model/user.model.ts
+++ b/packages/common/src/database/model/user.model.ts
@@ -1,5 +1,5 @@
 import { InferModel } from 'drizzle-orm';
-import { users } from '../schema';
+import { users } from '~/database/schema';
 
 type User = InferModel<typeof users>;
 

--- a/packages/common/src/utils/mergeObjects.test.ts
+++ b/packages/common/src/utils/mergeObjects.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { JsonObject } from 'src/types';
+import { JsonObject } from '~/types';
 import mergeObjects from './mergeObjects';
 
 describe('mergeObjects', () => {

--- a/packages/common/src/utils/mergeObjects.ts
+++ b/packages/common/src/utils/mergeObjects.ts
@@ -1,4 +1,4 @@
-import { JsonObject } from 'src/types';
+import { JsonObject } from '~/types';
 
 const isObject = (item: any) => typeof item === 'object';
 

--- a/packages/common/src/zod/dto/auth/createUser.test.ts
+++ b/packages/common/src/zod/dto/auth/createUser.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
-import { JsonObject } from 'src/types';
 import { ZodIssueCode } from 'zod';
+import { JsonObject } from '~/types';
 import { createUserDTO, CreateUserDTO } from './createUser';
 
 describe('createUserDTO', () => {

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -6,6 +6,9 @@
     "incremental": true,
     "module": "commonjs",
     "outDir": "./dist",
+    "paths": {
+      "~/*": ["./src/*"]
+    },
     "removeComments": true,
     "sourceMap": true,
     "target": "es2017"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1492,6 +1492,7 @@ __metadata:
     drizzle-orm: ^0.27.0
     eslint-plugin-import: ^2.27.5
     mocha: ^10.2.0
+    tsconfig-paths: 4.2.0
     typescript: ^5.0.4
     zod: ^3.21.4
   languageName: unknown


### PR DESCRIPTION
DESC
----
- common 패키지의 import 가독성을 향상시키기 위해 path alias 적용

NOTE
----
- test 코드 혹은 동일 폴더 안에서의 의존성 등 상대 경로가 필요한 경우 path alias를 사용하지 않음