### PR TITLE
fix : common 패키지에 설정해 두었던 path alias를 제거

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2253,7 +2253,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["drizzle-orm", "virtual:a16ae7f139ed3027b91dedc7271f0dba1d11ff76ae1acdf45c56d603088952facf7a0dd6438de36245f734e7f1860aee3e0a3834922f39b79cdbecb14afe37da#npm:0.27.0"],\
             ["eslint-plugin-import", "virtual:ec460f7b9669e9526be8d95ae865879fa75c18cc6dd56e9b411673f447efcb78b543355086075a52c7ac25d888e2171e528ed008b24aaf36bb94fbde779182d8#npm:2.27.5"],\
             ["mocha", "npm:10.2.0"],\
-            ["tsconfig-paths", "npm:4.2.0"],\
             ["typescript", "patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"],\
             ["zod", "npm:3.21.4"]\
           ],\

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -21,7 +21,6 @@
     "drizzle-orm": "^0.27.0",
     "eslint-plugin-import": "^2.27.5",
     "mocha": "^10.2.0",
-    "tsconfig-paths": "4.2.0",
     "typescript": "^5.0.4"
   },
   "scripts": {

--- a/packages/common/src/database/model/user.model.ts
+++ b/packages/common/src/database/model/user.model.ts
@@ -1,5 +1,5 @@
 import { InferModel } from 'drizzle-orm';
-import { users } from '~/database/schema';
+import { users } from '../schema';
 
 type User = InferModel<typeof users>;
 

--- a/packages/common/src/utils/mergeObjects.test.ts
+++ b/packages/common/src/utils/mergeObjects.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { JsonObject } from '~/types';
+import { beforeEach, describe, it } from 'mocha';
+import { JsonObject } from '../types';
 import mergeObjects from './mergeObjects';
 
 describe('mergeObjects', () => {

--- a/packages/common/src/utils/mergeObjects.ts
+++ b/packages/common/src/utils/mergeObjects.ts
@@ -1,4 +1,4 @@
-import { JsonObject } from '~/types';
+import { JsonObject } from '../types';
 
 const isObject = (item: any) => typeof item === 'object';
 

--- a/packages/common/src/zod/dto/auth/createUser.test.ts
+++ b/packages/common/src/zod/dto/auth/createUser.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
 import { ZodIssueCode } from 'zod';
-import { JsonObject } from '~/types';
+import { JsonObject } from '../../../types';
 import { createUserDTO, CreateUserDTO } from './createUser';
 
 describe('createUserDTO', () => {

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,14 +1,12 @@
 {
   "extends": "../../tsconfig.json",
+  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "baseUrl": "./",
     "declaration": true,
     "incremental": true,
     "module": "commonjs",
     "outDir": "./dist",
-    "paths": {
-      "~/*": ["./src/*"]
-    },
     "removeComments": true,
     "sourceMap": true,
     "target": "es2017"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1646,7 +1646,6 @@ __metadata:
     drizzle-orm: ^0.27.0
     eslint-plugin-import: ^2.27.5
     mocha: ^10.2.0
-    tsconfig-paths: 4.2.0
     typescript: ^5.0.4
     zod: ^3.21.4
   languageName: unknown


### PR DESCRIPTION
DESC
----
- common 패키지에 path alias를 설정할 경우, backend 패키지 등에 설정된 path alias와 충돌하여 서버가 실행되지 않음
- 따라서 common 패키지에 설치된 path alias를 제거함