### PR TITLE
feat : E-Mail 전송 기능 생성

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
           EMAIL_PASS: ${{secrets.EMAIL_PASS}}
           EMAIL_ADDRESS: ${{secrets.EMAIL_ADDRESS}}
           EMAIL_PASSWORD: ${{secrets.EMAIL_PASSWORD}}
+          EMAIL_TEST_ADDRESS: ${{secrets.EMAIL_TEST_ADDRESS}}
 
           BE_PORT: ${{ vars.BE_PORT }}
           FE_PORT: ${{ vars.FE_PORT }}

--- a/packages/backend/src/modules/email/email.service.spec.ts
+++ b/packages/backend/src/modules/email/email.service.spec.ts
@@ -17,4 +17,16 @@ describe('EmailService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+
+  describe('sendTestEmail', () => {
+    it('should work', async () => {
+      const target = process.env.EMAIL_TEST_ADDRESS as string;
+      await expect(service.sendTestEmail(target)).resolves.not.toThrow();
+    });
+
+    it('should throw with invalid email address', async () => {
+      const target = 'invalid@email';
+      await expect(async () => await service.sendTestEmail(target)).rejects.toThrow();
+    });
+  });
 });

--- a/packages/backend/src/modules/email/email.service.ts
+++ b/packages/backend/src/modules/email/email.service.ts
@@ -1,13 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createTransport } from 'nodemailer';
+import { z } from 'zod';
 import { Env } from '~/types';
 
 @Injectable()
 export class EmailService {
+  private readonly transport;
+  private readonly sender;
+
   constructor(configService: ConfigService<Env>) {
     // https://velog.io/@mimi0905/Nodemailer%EB%A1%9C-%EB%A9%94%EC%9D%BC-%EB%B3%B4%EB%82%B4%EA%B8%B0-with-%EC%B2%A8%EB%B6%80%ED%8C%8C%EC%9D%BC
-    createTransport({
+    this.transport = createTransport({
       host: configService.getOrThrow<Env['EMAIL_HREF']>('EMAIL_HREF'),
       port: configService.getOrThrow<Env['EMAIL_PORT']>('EMAIL_PORT'),
       secure: false,
@@ -15,6 +19,17 @@ export class EmailService {
         user: configService.getOrThrow<Env['EMAIL_USER']>('EMAIL_USER'),
         pass: configService.getOrThrow<Env['EMAIL_PASS']>('EMAIL_PASS'),
       },
+    });
+
+    this.sender = configService.getOrThrow<Env['EMAIL_ADDRESS']>('EMAIL_ADDRESS');
+  }
+
+  sendTestEmail(target: string) {
+    return this.transport.sendMail({
+      from: this.sender,
+      to: z.string().email().parse(target),
+      subject: 'test',
+      html: 'test mail',
     });
   }
 }


### PR DESCRIPTION
DESC
----
- EmailService에 E-Mail 전송 기능 생성

TEST
---
1. 환경 변수 `EMAIL_TEST_ADDRESS`에 E-Mail 값을 저장
2. 테스트 코드를 실행한 뒤 환경 변수로 지정한 이메일에 테스트 이메일이 왔는지 확인
  - mailtrap 등 테스트 환경을 사용하고 있다면 해당 환경 역시 확인

NOTE
----
- E-Mail 기능은 controller를 통해 접근하는 기능이 아님