### PR TITLE
feat : createUser 호출 시 바로 사용자를 생성하지 않고 변수에 잠시 저장

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2219,6 +2219,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/nodemailer", "npm:6.4.8"],\
             ["@types/pg", "npm:8.10.2"],\
             ["@types/supertest", "npm:2.0.12"],\
+            ["@types/uuid", "npm:9.0.2"],\
             ["@typescript-eslint/eslint-plugin", "virtual:e96441f8d0c35e985c5ba196554d76a3c79a59df59d90231dbf951dcf460b16cfac56e994239cc949b1697a8447f744cad17f1769651344951e0398e16836eb5#npm:5.59.0"],\
             ["dotenv", "npm:16.3.1"],\
             ["dotenv-expand", "npm:10.0.0"],\
@@ -2237,6 +2238,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ts-node", "virtual:e96441f8d0c35e985c5ba196554d76a3c79a59df59d90231dbf951dcf460b16cfac56e994239cc949b1697a8447f744cad17f1769651344951e0398e16836eb5#npm:10.9.1"],\
             ["tsconfig-paths", "npm:4.2.0"],\
             ["typescript", "patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"],\
+            ["uuid", "npm:9.0.0"],\
             ["zod", "npm:3.21.4"]\
           ],\
           "linkType": "SOFT"\

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,6 +29,7 @@
     "pg": "^8.11.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0",
+    "uuid": "^9.0.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "@types/nodemailer": "^6.4.8",
     "@types/pg": "^8.10.2",
     "@types/supertest": "^2.0.11",
+    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",

--- a/packages/backend/src/modules/auth/auth.controller.spec.ts
+++ b/packages/backend/src/modules/auth/auth.controller.spec.ts
@@ -8,7 +8,7 @@ describe('AuthController', () => {
 
   beforeEach(async () => {
     const mockAuthService = {
-      createUser: (data: any) => createUserDTO.parseAsync(data),
+      createUser: (data: any) => createUserDTO.parse(data),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -27,13 +27,13 @@ describe('AuthController', () => {
   });
 
   describe('createUser', () => {
-    it('should work', async () => {
+    it('should work', () => {
       const userToAdd = { email: 'create@example.email' };
-      await expect(controller.createUser(userToAdd)).resolves.not.toThrow();
+      expect(() => controller.createUser(userToAdd)).not.toThrow();
     });
 
     describe('should throw error with', () => {
-      it('non-object', async () => {
+      it('non-object', () => {
         const data = 'create@example.email';
         expect(() => controller.createUser(data)).toThrow();
       });

--- a/packages/backend/src/modules/auth/auth.service.spec.ts
+++ b/packages/backend/src/modules/auth/auth.service.spec.ts
@@ -1,9 +1,10 @@
 import { CreateUserDTO } from '@my-task/common';
 import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
-import { AuthService } from '~/modules/auth/auth.service';
+import { z } from 'zod';
 import { DatabaseProvider } from '~/modules/database/database.provider';
 import { DatabaseService } from '~/modules/database/database.service';
+import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -39,10 +40,19 @@ describe('AuthService', () => {
   });
 
   describe('createUser', () => {
-    it('should work (validation will be in controller)', async () => {
+    it('should work (validation will be in controller)', () => {
       const userToAdd: CreateUserDTO = { email: 'create@example.email' };
-      const createdUser = await service.createUser(userToAdd);
-      expect(createdUser.email).toEqual(userToAdd.email);
+      const result = service.createUser(userToAdd);
+      const parsedResult = z.string().uuid().safeParse(result);
+      expect(parsedResult.success).toEqual(true);
+    });
+
+    describe('should throw error when', () => {
+      it('pass same parameter', async () => {
+        const userToAdd: CreateUserDTO = { email: 'duplicate@example.email' };
+        service.createUser(userToAdd);
+        expect(() => service.createUser(userToAdd)).toThrow();
+      });
     });
   });
 });

--- a/packages/backend/src/modules/auth/auth.service.ts
+++ b/packages/backend/src/modules/auth/auth.service.ts
@@ -1,10 +1,14 @@
 import { CreateUserDTO, users } from '@my-task/common';
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
 import { DatabaseService } from '~/modules/database/database.service';
 
 @Injectable()
 export class AuthService {
   private readonly db;
+  private readonly uuidToEmail = new Map<string, CreateUserDTO>();
+  private readonly pendingEmail = new Set<string>();
+
   constructor(databaseService: DatabaseService) {
     this.db = databaseService.db;
   }
@@ -13,10 +17,13 @@ export class AuthService {
     return this.db.select().from(users).execute();
   }
 
-  async createUser(dto: CreateUserDTO) {
-    const insertedUsers = await this.db.insert(users).values(dto).returning();
+  createUser(dto: CreateUserDTO) {
+    if (this.pendingEmail.has(dto.email)) throw new BadRequestException('Emali already exists!');
 
-    if (insertedUsers.length !== 1) throw new InternalServerErrorException('DB insertion failed!');
-    else return insertedUsers[0];
+    const uuid = uuidv4();
+
+    this.uuidToEmail.set(uuid, dto);
+    this.pendingEmail.add(dto.email);
+    return uuid;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,6 +1614,7 @@ __metadata:
     "@types/nodemailer": ^6.4.8
     "@types/pg": ^8.10.2
     "@types/supertest": ^2.0.11
+    "@types/uuid": ^9.0.2
     "@typescript-eslint/eslint-plugin": ^5.59.0
     dotenv: ^16.3.1
     dotenv-expand: ^10.0.0
@@ -1632,6 +1633,7 @@ __metadata:
     ts-node: ^10.0.0
     tsconfig-paths: 4.2.0
     typescript: ^4.7.4
+    uuid: ^9.0.0
     zod: ^3.21.4
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
DESC
----
- E-Mail 기반 회원가입을 구현하기 위해선 post 한번에 회원가입이 되어서는 안됨
- createUser 메소드를 호출한 경우 바로 회원가입이 되는 대신 로컬 변수에 임시로 저장

NOTE
----
- DB 호출을 더이상 진행하지 않으므로 메소드를 동기 메소드로 변경