### PR TITLE
feat : 회원가입 확정 API 생성

### DIFF
--- a/packages/backend/src/modules/auth/auth.controller.spec.ts
+++ b/packages/backend/src/modules/auth/auth.controller.spec.ts
@@ -1,14 +1,32 @@
-import { createUserDTO } from '@my-task/common';
+import { CreateUserConfirmDTO, CreateUserDTO, User } from '@my-task/common';
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { v4 as uuidv4 } from 'uuid';
 import { AuthService } from '~/modules/auth/auth.service';
 import { AuthController } from './auth.controller';
 
 describe('AuthController', () => {
+  let mockAuthService: any;
   let controller: AuthController;
 
   beforeEach(async () => {
-    const mockAuthService = {
-      createUser: (data: any) => createUserDTO.parse(data),
+    mockAuthService = {
+      uuidToEmail: new Map<string, CreateUserDTO>(),
+      emailToUuid: new Map<string, string>(),
+      createUser(dto: CreateUserDTO) {
+        const uuid = uuidv4();
+        this.uuidToEmail.set(uuid, dto);
+        this.emailToUuid.set(dto.email, uuid);
+        return uuid;
+      },
+      createUserConfirm(dto: CreateUserConfirmDTO) {
+        if (!this.uuidToEmail.has(dto.uuid))
+          throw new BadRequestException('UUID cannot be found: Wrong DTO!');
+        const data = this.uuidToEmail.get(dto.uuid) as CreateUserDTO;
+
+        const user: User = { id: Math.floor(Math.random() * 10), ...data };
+        return user;
+      },
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -36,6 +54,32 @@ describe('AuthController', () => {
       it('non-object', () => {
         const data = 'create@example.email';
         expect(() => controller.createUser(data)).toThrow();
+      });
+    });
+  });
+
+  describe('createUserConfirm', () => {
+    it('should work', async () => {
+      const userToAdd = { email: 'create@example.email' };
+      const { email } = controller.createUser(userToAdd);
+
+      const uuid = mockAuthService?.emailToUuid?.get(email);
+      let user: User;
+      expect((user = await controller.createUserConfirm({ uuid }))).toBeDefined();
+      expect(user.email).toEqual(userToAdd.email);
+    });
+
+    describe('should throw error with', () => {
+      it('wrong dto', async () => {
+        const wrongUUID = 'this is not uuid';
+        await expect(async () =>
+          controller.createUserConfirm({ uuid: wrongUUID }),
+        ).rejects.toThrow();
+      });
+
+      it('non-existing uuid', async () => {
+        const uuid = uuidv4();
+        await expect(async () => controller.createUserConfirm({ uuid })).rejects.toThrow();
       });
     });
   });

--- a/packages/backend/src/modules/auth/auth.controller.ts
+++ b/packages/backend/src/modules/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { createUserDTO } from '@my-task/common';
+import { createUserConfirmDTO, createUserDTO } from '@my-task/common';
 import { BadRequestException, Body, Controller, Post } from '@nestjs/common';
 import { AuthService } from '~/modules/auth/auth.service';
 
@@ -8,10 +8,16 @@ export class AuthController {
 
   @Post()
   createUser(@Body() body: any) {
-    try {
-      return this.authService.createUser(createUserDTO.parse(body));
-    } catch (error) {
-      throw new BadRequestException('Wrong DTO: try again!');
-    }
+    const parsedBody = createUserDTO.safeParse(body);
+    if (!parsedBody.success) throw new BadRequestException('Wrong DTO: try again!');
+    this.authService.createUser(parsedBody.data);
+    return parsedBody.data;
+  }
+
+  @Post('confirm')
+  createUserConfirm(@Body() body: any) {
+    const parsedBody = createUserConfirmDTO.safeParse(body);
+    if (!parsedBody.success) throw new BadRequestException('Wrong DTO: try again!');
+    return this.authService.createUserConfirm(parsedBody.data);
   }
 }

--- a/packages/backend/src/modules/auth/auth.service.spec.ts
+++ b/packages/backend/src/modules/auth/auth.service.spec.ts
@@ -1,6 +1,7 @@
-import { CreateUserDTO } from '@my-task/common';
+import { CreateUserDTO, User } from '@my-task/common';
 import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import { DatabaseProvider } from '~/modules/database/database.provider';
 import { DatabaseService } from '~/modules/database/database.service';
@@ -48,10 +49,36 @@ describe('AuthService', () => {
     });
 
     describe('should throw error when', () => {
-      it('pass same parameter', async () => {
+      it('pass same parameter', () => {
         const userToAdd: CreateUserDTO = { email: 'duplicate@example.email' };
         service.createUser(userToAdd);
         expect(() => service.createUser(userToAdd)).toThrow();
+      });
+    });
+  });
+
+  describe('createUserConfirm (validation will be in controller)', () => {
+    it('should work', async () => {
+      const userToAdd: CreateUserDTO = { email: 'create@example.email' };
+      const uuid = service.createUser(userToAdd);
+
+      let createdUser: User = { id: -1, email: '' };
+      expect((createdUser = await service.createUserConfirm({ uuid }))).toBeDefined();
+      expect(createdUser.email).toEqual(userToAdd.email);
+    });
+
+    describe('should throw error when', () => {
+      it('non-existing uuid', async () => {
+        const uuid = uuidv4();
+        await expect(async () => service.createUserConfirm({ uuid })).rejects.toThrow();
+      });
+
+      it('pass same parameter', async () => {
+        const userToAdd: CreateUserDTO = { email: 'create@example.email' };
+        const uuid = service.createUser(userToAdd);
+
+        await service.createUserConfirm({ uuid });
+        await expect(async () => service.createUserConfirm({ uuid })).rejects.toThrow();
       });
     });
   });


### PR DESCRIPTION
DESC
----
- 회원가입 요청 시 생성된 uuid를 이용해 회원가입 확정 요청을 보낼 수 있는 API를 생성

NOTE
----
- 테스트를 위해 회원가입 요청 시 service에서 uuid를 반환하도록 설정