### PR TITLE
feat : 회원가입 확정 E-Mail 기능 생성

### DIFF
--- a/packages/backend/src/modules/email/email.service.ts
+++ b/packages/backend/src/modules/email/email.service.ts
@@ -1,35 +1,55 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createTransport } from 'nodemailer';
-import { z } from 'zod';
+import Mail from 'nodemailer/lib/mailer';
 import { Env } from '~/types';
 
 @Injectable()
-export class EmailService {
+export class EmailService implements OnModuleDestroy {
   private readonly transport;
   private readonly sender;
 
-  constructor(configService: ConfigService<Env>) {
+  constructor(private readonly configService: ConfigService<Env>) {
     // https://velog.io/@mimi0905/Nodemailer%EB%A1%9C-%EB%A9%94%EC%9D%BC-%EB%B3%B4%EB%82%B4%EA%B8%B0-with-%EC%B2%A8%EB%B6%80%ED%8C%8C%EC%9D%BC
     this.transport = createTransport({
-      host: configService.getOrThrow<Env['EMAIL_HREF']>('EMAIL_HREF'),
-      port: configService.getOrThrow<Env['EMAIL_PORT']>('EMAIL_PORT'),
+      pool: true,
+      host: this.configService.getOrThrow<Env['EMAIL_HREF']>('EMAIL_HREF'),
+      port: this.configService.getOrThrow<Env['EMAIL_PORT']>('EMAIL_PORT'),
       secure: false,
       auth: {
-        user: configService.getOrThrow<Env['EMAIL_USER']>('EMAIL_USER'),
-        pass: configService.getOrThrow<Env['EMAIL_PASS']>('EMAIL_PASS'),
+        user: this.configService.getOrThrow<Env['EMAIL_USER']>('EMAIL_USER'),
+        pass: this.configService.getOrThrow<Env['EMAIL_PASS']>('EMAIL_PASS'),
       },
     });
 
-    this.sender = configService.getOrThrow<Env['EMAIL_ADDRESS']>('EMAIL_ADDRESS');
+    this.sender = this.configService.getOrThrow<Env['EMAIL_ADDRESS']>('EMAIL_ADDRESS');
   }
 
-  sendTestEmail(target: string) {
-    return this.transport.sendMail({
-      from: this.sender,
-      to: z.string().email().parse(target),
-      subject: 'test',
-      html: 'test mail',
-    });
+  onModuleDestroy() {
+    return this.transport.close();
+  }
+
+  sendEmail(target: string, title: string, body: string) {
+    const mailOption: Mail.Options = {
+      from: `MyTask <${this.sender}>`,
+      sender: this.sender,
+      to: target,
+      subject: title,
+      html: body,
+    };
+
+    return this.transport.sendMail(mailOption);
+  }
+
+  sendJoinEmail(target: string, uuid: string) {
+    const HOST = this.configService.getOrThrow<Env['HOST']>('HOST');
+    const FE_PORT = this.configService.getOrThrow<Env['FE_PORT']>('FE_PORT');
+    const FE_ORIGIN = `http://${HOST}:${FE_PORT}`;
+
+    return this.sendEmail(
+      target,
+      '[MyTask] Please verify your E-Mail!',
+      `Click <a href="${FE_ORIGIN}/welcome/${uuid}">HERE</a> to verify your E-Mail!`,
+    );
   }
 }


### PR DESCRIPTION
DESC
----
- 회원가입 확정을 위해 사용자에게 회원가입 확정 요청 E-Mail을 발송하는 기능을 생성

NOTE
----
- 추후 다른 종류의 E-Mail을 보낼 수 있으므로, 메일에 담을 정보를 설정하는 메소드와 실제로 메일을 보내는 메소드를 분리함
- E-Mail로 발송되는 링크는 uuid를 사용하고 있으므로, FE의 welcome 페이지를 base64 기반에서 uuid 기반으로 전환해야 함