### PR TITLE
feat : 회원가입 API 호출 시 회원가입 확정 안내 메일 발송

### DIFF
--- a/packages/backend/src/modules/auth/auth.controller.spec.ts
+++ b/packages/backend/src/modules/auth/auth.controller.spec.ts
@@ -2,11 +2,13 @@ import { CreateUserConfirmDTO, CreateUserDTO, User } from '@my-task/common';
 import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { v4 as uuidv4 } from 'uuid';
-import { AuthService } from '~/modules/auth/auth.service';
+import { EmailService } from '~/modules/email/email.service';
 import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
 
 describe('AuthController', () => {
   let mockAuthService: any;
+  let mockEmailService: any;
   let controller: AuthController;
 
   beforeEach(async () => {
@@ -29,10 +31,17 @@ describe('AuthController', () => {
       },
     };
 
+    mockEmailService = {
+      sendJoinEmail: (target: string, uuid: string) =>
+        new Promise((resolve) => resolve({ target, uuid })),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [EmailService, AuthService],
       controllers: [AuthController],
     })
+      .overrideProvider(EmailService)
+      .useValue(mockEmailService)
       .overrideProvider(AuthService)
       .useValue(mockAuthService)
       .compile();

--- a/packages/backend/src/modules/auth/auth.controller.ts
+++ b/packages/backend/src/modules/auth/auth.controller.ts
@@ -1,23 +1,31 @@
-import { createUserConfirmDTO, createUserDTO } from '@my-task/common';
+import { createUserConfirmDTO, createUserDTO, parseWithZod } from '@my-task/common';
 import { BadRequestException, Body, Controller, Post } from '@nestjs/common';
-import { AuthService } from '~/modules/auth/auth.service';
+import { EmailService } from '~/modules/email/email.service';
+import { AuthService } from './auth.service';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly emailService: EmailService,
+  ) {}
 
   @Post()
   createUser(@Body() body: any) {
-    const parsedBody = createUserDTO.safeParse(body);
-    if (!parsedBody.success) throw new BadRequestException('Wrong DTO: try again!');
-    this.authService.createUser(parsedBody.data);
-    return parsedBody.data;
+    const { data, error } = parseWithZod(body, createUserDTO);
+    if (!data || error) throw new BadRequestException('Wrong DTO: try again!');
+
+    const uuid = this.authService.createUser(data);
+    // E-Mail 송신은 동기적으로 진행할 필요 없음
+    this.emailService.sendJoinEmail(data.email, uuid);
+
+    return data;
   }
 
   @Post('confirm')
   createUserConfirm(@Body() body: any) {
-    const parsedBody = createUserConfirmDTO.safeParse(body);
-    if (!parsedBody.success) throw new BadRequestException('Wrong DTO: try again!');
-    return this.authService.createUserConfirm(parsedBody.data);
+    const { data, error } = parseWithZod(body, createUserConfirmDTO);
+    if (!data || error) throw new BadRequestException('Wrong DTO: try again!');
+    return this.authService.createUserConfirm(data);
   }
 }

--- a/packages/backend/src/modules/email/email.module.ts
+++ b/packages/backend/src/modules/email/email.module.ts
@@ -1,7 +1,9 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { EmailService } from './email.service';
 
+@Global()
 @Module({
-  providers: [EmailService]
+  providers: [EmailService],
+  exports: [EmailService],
 })
 export class EmailModule {}


### PR DESCRIPTION
DESC
----
- 회원가입 신청 시 입력받은 E-Mail 주소로 회원가입 확정 안내 메일을 발송

NOTE
----
- E-Mail로 발송되는 링크는 uuid를 사용하고 있으므로, FE의 welcome 페이지를 base64 기반에서 uuid 기반으로 전환해야 함