### PR TITLE
fix : 바뀐 명세에 맞게 postJoin 수정

### DIFF
--- a/packages/frontend/src/api/postJoin.test.tsx
+++ b/packages/frontend/src/api/postJoin.test.tsx
@@ -7,7 +7,7 @@ import { BE_ORIGIN } from '~/constants';
 import { server } from '~/mock';
 
 describe('postJoin', () => {
-  let renderedHook: RenderHookResult<UseMutationResult<any, any, Object, any>, unknown>;
+  let renderedHook: RenderHookResult<UseMutationResult<any, any, CreateUserDTO, any>, unknown>;
 
   const testQueryClient = new QueryClient({
     defaultOptions: {
@@ -50,11 +50,6 @@ describe('postJoin', () => {
   });
 
   describe('should fail with', () => {
-    it('empty email', async () => {
-      renderedHook.result.current.mutate({});
-      await waitFor(() => expect(renderedHook.result.current.isError).toEqual(true));
-    });
-
     it('invalid email', async () => {
       renderedHook.result.current.mutate({ email: 'invalid@email' });
       await waitFor(() => expect(renderedHook.result.current.isError).toEqual(true));

--- a/packages/frontend/src/api/postJoin.ts
+++ b/packages/frontend/src/api/postJoin.ts
@@ -1,4 +1,4 @@
-import { User } from '@my-task/common';
+import { CreateUserDTO } from '@my-task/common';
 import { useMutation } from '@tanstack/react-query';
 import fetchCore from '~/api/fetchCore';
 
@@ -10,7 +10,8 @@ type MutationOption = {
 
 const postJoin = ({ onSuccess, onError }: MutationOption) =>
   useMutation({
-    mutationFn: (body: Object) => fetchCore<User>('/auth', { method: 'POST', body }),
+    mutationFn: (body: CreateUserDTO) =>
+      fetchCore<CreateUserDTO>('/auth', { method: 'POST', body }),
     onSuccess,
     onError,
   });

--- a/packages/frontend/src/mock/handlers.ts
+++ b/packages/frontend/src/mock/handlers.ts
@@ -22,8 +22,6 @@ export const handlers = [
     const { data, error } = parseWithZod(body, createUserDTO);
 
     if (error) return res(ctx.status(400), ctx.json({ errorMessage: 'Wrong DTO: try again!' }));
-
-    const id = Math.floor(Math.random() * 10);
-    return res(ctx.status(200), ctx.json({ ...data, id }));
+    return res(ctx.status(200), ctx.json(data));
   }),
 ];


### PR DESCRIPTION
DESC
----
- postJoin.mutate 실행 시 바뀐 Backend 명세에 맞게 받은 DTO를 그대로 받아오도록 수정