### PR TITLE
feat : 회원가입 확정 요청 API 생성

### DIFF
--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -1,3 +1,4 @@
 import getConnectionTest from './getConnectionTest';
+import joinUserConfirm from './joinUserConfirm';
 import postJoin from './postJoin';
-export { getConnectionTest, postJoin };
+export { getConnectionTest, postJoin, joinUserConfirm };

--- a/packages/frontend/src/api/joinUserConfirm.test.tsx
+++ b/packages/frontend/src/api/joinUserConfirm.test.tsx
@@ -1,0 +1,62 @@
+import { CreateUserConfirmDTO, User } from '@my-task/common';
+import { QueryClient, QueryClientProvider, UseMutationResult } from '@tanstack/react-query';
+import { RenderHookResult, renderHook, waitFor } from '@testing-library/react';
+import { describe, expectTypeOf } from 'vitest';
+import { BE_ORIGIN } from '~/constants';
+import { server } from '~/mock';
+import createUserConfirm from './joinUserConfirm';
+
+describe('postJoin', () => {
+  let renderedHook: RenderHookResult<
+    UseMutationResult<any, any, CreateUserConfirmDTO, any>,
+    unknown
+  >;
+
+  const testQueryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+    logger: {
+      log: console.log,
+      warn: console.warn,
+      error: () => {},
+    },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
+  beforeEach(() => location.replace(BE_ORIGIN));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  beforeEach(() => {
+    renderedHook = renderHook(() => createUserConfirm({}), { wrapper });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+  });
+
+  it('should work', async () => {
+    const dto: CreateUserConfirmDTO = { uuid: '993ae2a1-2554-404c-8a86-660b5ee7fedd' };
+    renderedHook.result.current.mutate(dto);
+    await waitFor(() => expect(renderedHook.result.current.isSuccess).toEqual(true));
+
+    const data = renderedHook.result.current.data;
+    expectTypeOf(data).toMatchTypeOf<User>();
+    expect(data.email).toEqual('success@example.com');
+  });
+
+  describe('should fail with', () => {
+    it('invalid email', async () => {
+      const dto: CreateUserConfirmDTO = { uuid: '6aa6ee8e-a4f8-49f6-817f-1c9342aae29e' };
+      renderedHook.result.current.mutate(dto);
+      await waitFor(() => expect(renderedHook.result.current.isError).toEqual(true));
+    });
+  });
+});

--- a/packages/frontend/src/api/joinUserConfirm.ts
+++ b/packages/frontend/src/api/joinUserConfirm.ts
@@ -1,0 +1,19 @@
+import { CreateUserConfirmDTO, User } from '@my-task/common';
+import { useMutation } from '@tanstack/react-query';
+import fetchCore from './fetchCore';
+
+type Function = (...args: any[]) => any;
+type MutationOption = {
+  onSuccess?: Function;
+  onError?: Function;
+};
+
+const joinUserConfirm = ({ onSuccess, onError }: MutationOption) =>
+  useMutation({
+    mutationFn: (body: CreateUserConfirmDTO) =>
+      fetchCore<User>('/auth/confirm', { method: 'POST', body }),
+    onSuccess,
+    onError,
+  });
+
+export default joinUserConfirm;

--- a/packages/frontend/src/mock/handlers.ts
+++ b/packages/frontend/src/mock/handlers.ts
@@ -1,4 +1,4 @@
-import { createUserDTO, parseWithZod } from '@my-task/common';
+import { User, createUserConfirmDTO, createUserDTO, parseWithZod } from '@my-task/common';
 import { rest } from 'msw';
 import { BE_ORIGIN } from '~/constants';
 
@@ -23,5 +23,22 @@ export const handlers = [
 
     if (error) return res(ctx.status(400), ctx.json({ errorMessage: 'Wrong DTO: try again!' }));
     return res(ctx.status(200), ctx.json(data));
+  }),
+
+  rest.post(mockDir('/auth/confirm'), async (req, res, ctx) => {
+    const body = await req.json();
+
+    ctx.delay();
+
+    const { data, error } = parseWithZod(body, createUserConfirmDTO);
+    if (error) return res(ctx.status(400), ctx.json({ errorMessage: 'Wrong DTO: try again!' }));
+
+    if (data?.uuid === '6aa6ee8e-a4f8-49f6-817f-1c9342aae29e')
+      return res(ctx.status(400), ctx.json({ errorMessage: 'UUID cannot be found: Wrong DTO!' }));
+
+    const id = Math.floor(Math.random() * 10);
+    const success: User = { id, email: 'success@example.com' };
+
+    return res(ctx.status(200), ctx.json(success));
   }),
 ];


### PR DESCRIPTION
DESC
----
- 회원가입 확정 요청을 보내기 위한 API 생성

NOTE
----
- 회원가입에 실패하는 magic number uuid는 추후 별개의 magic number가 등장할 경우 handler와 함께 refactor할 예정