### PR TITLE
feat : 회원가입 후 표시할 Welcome 페이지 생성

### DIFF
--- a/packages/frontend/src/routes/Welcome/index.tsx
+++ b/packages/frontend/src/routes/Welcome/index.tsx
@@ -1,0 +1,14 @@
+import { RouteObject } from 'react-router-dom';
+import Welcome from './page';
+
+const welcomeRouteObject: RouteObject = {
+  path: 'welcome',
+  children: [
+    {
+      path: ':uuid',
+      element: <Welcome />,
+    },
+  ],
+};
+
+export default welcomeRouteObject;

--- a/packages/frontend/src/routes/Welcome/page.test.tsx
+++ b/packages/frontend/src/routes/Welcome/page.test.tsx
@@ -1,0 +1,63 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RenderResult, render, waitFor } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { BE_ORIGIN } from '~/constants';
+import { server } from '~/mock';
+import welcomeRouteObject from '.';
+
+describe('App', () => {
+  it('no test suite', () => {
+    expect(1).toEqual(1);
+  });
+  let screen: RenderResult;
+  const testQueryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+    logger: {
+      log: () => {},
+      warn: console.warn,
+      error: () => {},
+    },
+  });
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
+  beforeEach(() => location.replace(BE_ORIGIN));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  const renderWithRouter = (path: string) =>
+    render(
+      <QueryClientProvider client={testQueryClient}>
+        <RouterProvider
+          router={createMemoryRouter([welcomeRouteObject], {
+            initialEntries: [path],
+          })}
+        />
+      </QueryClientProvider>,
+    );
+
+  describe('Welcome', () => {
+    describe('should work', () => {
+      beforeEach(() => {
+        screen = renderWithRouter('/welcome/993ae2a1-2554-404c-8a86-660b5ee7fedd');
+      });
+
+      it('when loading', async () => {
+        const text = screen.getByText('Loading...');
+        expect(text).toBeDefined();
+      });
+
+      it('when success', async () => {
+        await waitFor(() => expect(testQueryClient.isMutating()).toEqual(0));
+
+        const text = screen.getByText('Welcome, success@example.com!');
+        expect(text).toBeDefined();
+      });
+    });
+  });
+});

--- a/packages/frontend/src/routes/Welcome/page.tsx
+++ b/packages/frontend/src/routes/Welcome/page.tsx
@@ -1,0 +1,34 @@
+import { User, parseWithZod } from '@my-task/common';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { z } from 'zod';
+import { joinUserConfirm } from '~/api';
+
+const Welcome = () => {
+  const { uuid } = useParams();
+  const [email, setEmail] = useState<string>();
+  const [error, setError] = useState<any>();
+
+  const joinConfirm = joinUserConfirm({
+    onSuccess: (data: User) => {
+      console.log(data); // striceMode를 사용하므로 디버깅을 위함
+      setEmail(data.email as string);
+    },
+    onError: (err) => setError(err),
+  });
+
+  if (error) throw error;
+
+  if (!email && !error && !joinConfirm.isLoading) {
+    const result = parseWithZod(uuid, z.string().uuid());
+
+    if (result.error) throw result.error;
+    else if (!result.data) throw { errorMessage: '잘못된 경로로 Welcome 페이지에 접근하였습니다!' };
+
+    joinConfirm.mutate({ uuid: result.data });
+  }
+
+  return email ? <div>Welcome, {email}!</div> : <div>Loading...</div>;
+};
+
+export default Welcome;

--- a/packages/frontend/src/routes/index.ts
+++ b/packages/frontend/src/routes/index.ts
@@ -1,7 +1,8 @@
 import { createBrowserRouter } from 'react-router-dom';
+import welcomeRouteObject from '~/routes/Welcome';
 import joinRouteObject from './Join';
 import rootRouteObject from './Root';
 
-const router = createBrowserRouter([rootRouteObject, joinRouteObject]);
+const router = createBrowserRouter([rootRouteObject, joinRouteObject, welcomeRouteObject]);
 
 export default router;


### PR DESCRIPTION
DESC
----
- 회원가입 요청 시 생성된 uuid를 param을 통해 인자로 받을 경우 보여줄 welcome 페이지 생성

TEST
----
1. 백엔드 서버와 프론트엔드 서버를 각각 실행
2. 프론트엔드 페이지의 /join 디렉토리에 접속한 뒤 E-Mail을 입력하고 회원가입 버튼을 클릭
3. 입력한 주소로 전송된 이메일에 적힌 URL을 클릭
4. Welcome 페이지가 제대로 표시되는지 확인

NOTE
----
- E-Mail을 받지 못하거나 잘못된 값이 들어올 경우는 추가 PR을 통해 push