### PR TITLE
feat : welcome 페이지에 잘못된 값이 들어올 경우 에러 페이지 표시

### DIFF
--- a/packages/frontend/src/routes/Welcome/error.test.tsx
+++ b/packages/frontend/src/routes/Welcome/error.test.tsx
@@ -1,0 +1,68 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RenderResult, render, waitFor } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { BE_ORIGIN } from '~/constants';
+import { server } from '~/mock';
+import welcomeRouteObject from '.';
+
+describe('App', () => {
+  let screen: RenderResult;
+  const testQueryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+    logger: {
+      log: () => {},
+      warn: console.warn,
+      error: () => {},
+    },
+  });
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
+  beforeEach(() => location.replace(BE_ORIGIN));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  const renderWithRouter = (path: string) =>
+    render(
+      <QueryClientProvider client={testQueryClient}>
+        <RouterProvider
+          router={createMemoryRouter([welcomeRouteObject], {
+            initialEntries: [path],
+          })}
+        />
+      </QueryClientProvider>,
+    );
+
+  describe('Welcome - Error', () => {
+    describe('should throw error when', () => {
+      it('insufficient path', async () => {
+        screen = renderWithRouter('/welcome');
+        await waitFor(() => expect(testQueryClient.isMutating()).toEqual(0));
+
+        const text = screen.getByText('Path Error : You need encoded email to join via this page!');
+        expect(text).toBeDefined();
+      });
+
+      it('invalid string', async () => {
+        screen = renderWithRouter('/welcome/@@@');
+        await waitFor(() => expect(testQueryClient.isMutating()).toEqual(0));
+
+        const text = screen.getByText('Parse Error : Given string cannot be parsed to UUID!');
+        expect(text).toBeDefined();
+      });
+
+      it('invalid uuid', async () => {
+        screen = renderWithRouter('/welcome/6aa6ee8e-a4f8-49f6-817f-1c9342aae29e');
+        await waitFor(() => expect(testQueryClient.isMutating()).toEqual(0));
+
+        const text = screen.getByText('UUID cannot be found: Wrong DTO!');
+        expect(text).toBeDefined();
+      });
+    });
+  });
+});

--- a/packages/frontend/src/routes/Welcome/error.tsx
+++ b/packages/frontend/src/routes/Welcome/error.tsx
@@ -1,0 +1,23 @@
+import { useRouteError } from 'react-router-dom';
+import { ZodError } from 'zod';
+
+const ErrorPage = () => {
+  const err = useRouteError() as any;
+
+  const message = (() => {
+    if (!err) return 'Path Error : You need encoded email to join via this page!';
+    else if (err.errorMessage !== undefined) return err.errorMessage as string;
+
+    switch (err.constructor) {
+      case ZodError:
+      case DOMException:
+        return 'Parse Error : Given string cannot be parsed to UUID!';
+      default:
+        return 'Something Went Wrong!';
+    }
+  })();
+
+  return <div>{message}</div>;
+};
+
+export default ErrorPage;

--- a/packages/frontend/src/routes/Welcome/index.tsx
+++ b/packages/frontend/src/routes/Welcome/index.tsx
@@ -1,9 +1,15 @@
 import { RouteObject } from 'react-router-dom';
+import ErrorPage from './error';
 import Welcome from './page';
 
 const welcomeRouteObject: RouteObject = {
   path: 'welcome',
+  errorElement: <ErrorPage />,
   children: [
+    {
+      path: '',
+      element: <ErrorPage />,
+    },
     {
       path: ':uuid',
       element: <Welcome />,


### PR DESCRIPTION
DESC
----
- Welcome 페이지의 uuid 위치에 아래 값이 들어올 경우 에러 페이지 표시
  - uuid가 들어오지 않은 경우
  - uuid가 아닌 문자열이 들어올 경우
  - uuid에 대응되는 E-Mail이 이미 처리된 경우
    - 이 경우는 uuid가 들어오지 않은 경우와 같이 처리됨 - 에러 처리 필요

TEST
----
1. 백엔드 서버와 프론트엔드 서버를 각각 실행
2. 아래 경우에 해당되는 문자열을 프론트엔드의 /welcome/${value}에 넣을 경우 에러 페이지가 표시되는지 확인
  - 빈 문자열
  - uuid가 아닌 문자열이 들어올 경우
  - E-Mail을 통해 받은 적 없는 uuid
  - 이미 한 번 사용한 uuid