### PR TITLE
refact : 실제 용도와 맞지 않는 환경 변수 이름 수정

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           DB_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           DB_DB: ${{ secrets.POSTGRES_DB }}
 
-          EMAIL_HREF: ${{secrets.EMAIL_HREF}}
+          EMAIL_HOST: ${{secrets.EMAIL_HOST}}
           EMAIL_PORT: ${{secrets.EMAIL_PORT}}
           EMAIL_USER: ${{secrets.EMAIL_USER}}
           EMAIL_PASS: ${{secrets.EMAIL_PASS}}

--- a/packages/backend/src/env/validate.spec.ts
+++ b/packages/backend/src/env/validate.spec.ts
@@ -16,7 +16,7 @@ describe('env validation', () => {
 
       BE_PORT: '3000',
 
-      EMAIL_HREF: 'smtp.gmail.com',
+      EMAIL_HOST: 'smtp.gmail.com',
       EMAIL_PORT: '587',
       EMAIL_USER: '',
       EMAIL_PASS: '',

--- a/packages/backend/src/env/validate.ts
+++ b/packages/backend/src/env/validate.ts
@@ -12,7 +12,7 @@ const envSchema = z
 
     BE_PORT: USER_PORT_RULE,
 
-    EMAIL_HREF: z.string(),
+    EMAIL_HOST: z.string(),
     EMAIL_PORT: PORT_RULE,
     EMAIL_USER: z.string(),
     EMAIL_PASS: z.string(),


### PR DESCRIPTION
DESC
----
- `HOST`로 사용되지만 `HREF`로 네이밍된 환경 변수 `EMAIL_HREF`의 네이밍을 `EMAIL_HOST`로 수정