### PR TITLE
refact : 이름이 겹쳐 혼동되는 환경 변수 이름 수정

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,8 +64,8 @@ jobs:
           EMAIL_PORT: ${{secrets.EMAIL_PORT}}
           EMAIL_USER: ${{secrets.EMAIL_USER}}
           EMAIL_PASS: ${{secrets.EMAIL_PASS}}
-          EMAIL_ADDRESS: ${{secrets.EMAIL_ADDRESS}}
-          EMAIL_TEST_ADDRESS: ${{secrets.EMAIL_TEST_ADDRESS}}
+          EMAIL_SENDER: ${{secrets.EMAIL_SENDER}}
+          EMAIL_TEST_RECEIVER: ${{secrets.EMAIL_TEST_RECEIVER}}
 
           BE_PORT: ${{ vars.BE_PORT }}
           FE_PORT: ${{ vars.FE_PORT }}

--- a/packages/backend/src/env/validate.spec.ts
+++ b/packages/backend/src/env/validate.spec.ts
@@ -20,7 +20,7 @@ describe('env validation', () => {
       EMAIL_PORT: '587',
       EMAIL_USER: '',
       EMAIL_PASS: '',
-      EMAIL_ADDRESS: 'test@example.com',
+      EMAIL_SENDER: 'test@example.com',
 
       FE_PORT: '5173',
     };
@@ -192,30 +192,30 @@ describe('env validation', () => {
     });
   });
 
-  describe('EMAIL_ADDRESS', () => {
+  describe('EMAIL_SENDER', () => {
     it('should work', () => {
       const parsedEnv = validate(testEnv);
-      expect(parsedEnv.EMAIL_ADDRESS).toEqual(testEnv.EMAIL_ADDRESS);
+      expect(parsedEnv.EMAIL_SENDER).toEqual(testEnv.EMAIL_SENDER);
     });
 
     describe('should throw error with', () => {
       it('empty field', () => {
-        delete testEnv.EMAIL_ADDRESS;
+        delete testEnv.EMAIL_SENDER;
         expect(() => validate(testEnv)).toThrow(ZodIssueCode.invalid_type);
       });
 
       it('invalid email', () => {
-        testEnv.EMAIL_ADDRESS = 'invalid.email';
+        testEnv.EMAIL_SENDER = 'invalid.email';
         expect(() => validate(testEnv)).toThrow(ZodIssueCode.invalid_string);
       });
 
       it('email with invalid domain', () => {
-        testEnv.EMAIL_ADDRESS = 'invalid@email.';
+        testEnv.EMAIL_SENDER = 'invalid@email.';
         expect(() => validate(testEnv)).toThrow(ZodIssueCode.invalid_string);
       });
 
       it('email with invalid identifier', () => {
-        testEnv.EMAIL_ADDRESS = '@invalid.email';
+        testEnv.EMAIL_SENDER = '@invalid.email';
         expect(() => validate(testEnv)).toThrow(ZodIssueCode.invalid_string);
       });
     });

--- a/packages/backend/src/env/validate.ts
+++ b/packages/backend/src/env/validate.ts
@@ -17,7 +17,7 @@ const envSchema = z
     EMAIL_USER: z.string(),
     EMAIL_PASS: z.string(),
 
-    EMAIL_ADDRESS: z.string().email(),
+    EMAIL_SENDER: z.string().email(),
 
     FE_PORT: USER_PORT_RULE,
   })

--- a/packages/backend/src/modules/email/email.service.spec.ts
+++ b/packages/backend/src/modules/email/email.service.spec.ts
@@ -6,7 +6,7 @@ import { EmailService } from './email.service';
 
 describe('EmailService', () => {
   let service: EmailService;
-  const target = process.env.EMAIL_TEST_ADDRESS as string;
+  const receiver = process.env.EMAIL_TEST_RECEIVER as string;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -29,14 +29,14 @@ describe('EmailService', () => {
     it('should work', async () => {
       let result: SMTPPool.SentMessageInfo;
       expect(
-        (result = await service.sendEmail(target, 'test', '<div>test123</div>')),
+        (result = await service.sendEmail(receiver, 'test', '<div>test123</div>')),
       ).toBeDefined();
       expect(result.accepted.length).toEqual(1);
       expect(result.rejected.length).toEqual(0);
     });
 
     describe('should throw error when', () => {
-      it('empty target', async () => {
+      it('empty receiver', async () => {
         await expect(
           async () => await service.sendEmail('', 'test', '<div>test123</div>'),
         ).rejects.toThrow();
@@ -47,7 +47,7 @@ describe('EmailService', () => {
   describe('sendJoinEmail', () => {
     it('should work', async () => {
       let result: SMTPPool.SentMessageInfo;
-      expect((result = await service.sendJoinEmail(target, uuidv4()))).toBeDefined();
+      expect((result = await service.sendJoinEmail(receiver, uuidv4()))).toBeDefined();
       expect(result.accepted.length).toEqual(1);
       expect(result.rejected.length).toEqual(0);
     });

--- a/packages/backend/src/modules/email/email.service.ts
+++ b/packages/backend/src/modules/email/email.service.ts
@@ -23,18 +23,18 @@ export class EmailService implements OnModuleDestroy {
       },
     });
 
-    this.sender = this.configService.getOrThrow<Env['EMAIL_ADDRESS']>('EMAIL_ADDRESS');
+    this.sender = this.configService.getOrThrow<Env['EMAIL_SENDER']>('EMAIL_SENDER');
   }
 
   onModuleDestroy() {
     return this.transport.close();
   }
 
-  sendEmail(target: string, title: string, body: string): Promise<SMTPPool.SentMessageInfo> {
+  sendEmail(receiver: string, title: string, body: string): Promise<SMTPPool.SentMessageInfo> {
     const mailOption: Mail.Options = {
       from: `MyTask <${this.sender}>`,
       sender: this.sender,
-      to: target,
+      to: receiver,
       subject: title,
       html: body,
     };
@@ -44,13 +44,13 @@ export class EmailService implements OnModuleDestroy {
     });
   }
 
-  sendJoinEmail(target: string, uuid: string) {
+  sendJoinEmail(receiver: string, uuid: string) {
     const HOST = this.configService.getOrThrow<Env['HOST']>('HOST');
     const FE_PORT = this.configService.getOrThrow<Env['FE_PORT']>('FE_PORT');
     const FE_ORIGIN = `http://${HOST}:${FE_PORT}`;
 
     return this.sendEmail(
-      target,
+      receiver,
       '[MyTask] Please verify your E-Mail!',
       `Click <a href="${FE_ORIGIN}/welcome/${uuid}">HERE</a> to verify your E-Mail!`,
     );


### PR DESCRIPTION
DESC
----
- 같은 `ADDRESS`라는 suffix를 공유하던 환경 변수 `EMAIL_ADDRESS`와 `EMAIL_TEST_ADDRESS`의 네이밍을 변경
  - `EMAIL_ADDRESS` -> `EMAIL_SENDER`
  - `EMAIL_TEST_ADDRESS` -> `EMAIL_TEST_RECEIVER`

NOTE
----
- `EMAIL_TEST_RECEIVER`를 사용하던 parameter의 이름 역시 `target`에서 `receiver`로 변경