### PR TITLE
test : 테스트에서 사용될 service mock을 각각 파일로 분리

### DIFF
--- a/packages/backend/src/mock/index.ts
+++ b/packages/backend/src/mock/index.ts
@@ -1,0 +1,1 @@
+export * from './services';

--- a/packages/backend/src/mock/services/auth.service.ts
+++ b/packages/backend/src/mock/services/auth.service.ts
@@ -1,0 +1,27 @@
+import { CreateUserConfirmDTO, CreateUserDTO, User } from '@my-task/common';
+import { BadRequestException } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+
+const mockAuthService = async () => ({
+  uuidToEmail: new Map<string, CreateUserDTO>(),
+  emailToUuid: new Map<string, string>(),
+  createUser(dto: CreateUserDTO) {
+    const uuid = uuidv4();
+    this.uuidToEmail.set(uuid, dto);
+    this.emailToUuid.set(dto.email, uuid);
+    return uuid;
+  },
+  createUserConfirm(dto: CreateUserConfirmDTO) {
+    if (!this.uuidToEmail.has(dto.uuid))
+      throw new BadRequestException('UUID cannot be found: Wrong DTO!');
+    const data = this.uuidToEmail.get(dto.uuid) as CreateUserDTO;
+
+    const user: User = { id: Math.floor(Math.random() * 10), ...data };
+    return user;
+  },
+});
+
+type MockAuthService = Awaited<ReturnType<typeof mockAuthService>>;
+
+export { mockAuthService };
+export type { MockAuthService };

--- a/packages/backend/src/mock/services/email.service.ts
+++ b/packages/backend/src/mock/services/email.service.ts
@@ -1,0 +1,9 @@
+const mockEmailService = async () => ({
+  sendJoinEmail: (target: string, uuid: string) =>
+    new Promise((resolve) => resolve({ target, uuid })),
+});
+
+type MockEmailService = Awaited<ReturnType<typeof mockEmailService>>;
+
+export { mockEmailService };
+export type { MockEmailService };

--- a/packages/backend/src/mock/services/index.ts
+++ b/packages/backend/src/mock/services/index.ts
@@ -1,0 +1,2 @@
+export * from './auth.service';
+export * from './email.service';

--- a/packages/backend/src/modules/auth/auth.controller.spec.ts
+++ b/packages/backend/src/modules/auth/auth.controller.spec.ts
@@ -1,49 +1,27 @@
-import { CreateUserConfirmDTO, CreateUserDTO, User } from '@my-task/common';
-import { BadRequestException } from '@nestjs/common';
+import { User } from '@my-task/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { v4 as uuidv4 } from 'uuid';
+import { MockAuthService, MockEmailService, mockAuthService, mockEmailService } from '~/mock';
 import { EmailService } from '~/modules/email/email.service';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 
 describe('AuthController', () => {
-  let mockAuthService: any;
-  let mockEmailService: any;
+  let authService: MockAuthService;
+  let emailService: MockEmailService;
   let controller: AuthController;
 
   beforeEach(async () => {
-    mockAuthService = {
-      uuidToEmail: new Map<string, CreateUserDTO>(),
-      emailToUuid: new Map<string, string>(),
-      createUser(dto: CreateUserDTO) {
-        const uuid = uuidv4();
-        this.uuidToEmail.set(uuid, dto);
-        this.emailToUuid.set(dto.email, uuid);
-        return uuid;
-      },
-      createUserConfirm(dto: CreateUserConfirmDTO) {
-        if (!this.uuidToEmail.has(dto.uuid))
-          throw new BadRequestException('UUID cannot be found: Wrong DTO!');
-        const data = this.uuidToEmail.get(dto.uuid) as CreateUserDTO;
-
-        const user: User = { id: Math.floor(Math.random() * 10), ...data };
-        return user;
-      },
-    };
-
-    mockEmailService = {
-      sendJoinEmail: (target: string, uuid: string) =>
-        new Promise((resolve) => resolve({ target, uuid })),
-    };
+    [authService, emailService] = await Promise.all([mockAuthService(), mockEmailService()]);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [EmailService, AuthService],
       controllers: [AuthController],
     })
       .overrideProvider(EmailService)
-      .useValue(mockEmailService)
+      .useValue(emailService)
       .overrideProvider(AuthService)
-      .useValue(mockAuthService)
+      .useValue(authService)
       .compile();
 
     controller = module.get<AuthController>(AuthController);
@@ -72,7 +50,7 @@ describe('AuthController', () => {
       const userToAdd = { email: 'create@example.email' };
       const { email } = controller.createUser(userToAdd);
 
-      const uuid = mockAuthService?.emailToUuid?.get(email);
+      const uuid = authService.emailToUuid.get(email);
       let user: User;
       expect((user = await controller.createUserConfirm({ uuid }))).toBeDefined();
       expect(user.email).toEqual(userToAdd.email);


### PR DESCRIPTION
DESC
----
- 각 테스트에서 사용되는 service mock 코드가 길어 테스트 코드의 가독성을 저하시킴
- 각 service mock을 별개 파일로 분리하여 코드의 가독성과 유지보수성을 향상시킴

#112 