### PR TITLE
test : 테스트에서 사용될 module mock을 각각 파일로 분리

### DIFF
--- a/packages/backend/src/mock/index.ts
+++ b/packages/backend/src/mock/index.ts
@@ -1,1 +1,2 @@
+export * from './modules';
 export * from './services';

--- a/packages/backend/src/mock/modules/auth.module.ts
+++ b/packages/backend/src/mock/modules/auth.module.ts
@@ -1,0 +1,37 @@
+import { Provider } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { MockAuthService, MockEmailService } from '~/mock';
+import { AuthController } from '~/modules/auth/auth.controller';
+import { AuthService } from '~/modules/auth/auth.service';
+import { DatabaseService } from '~/modules/database/database.service';
+import { EmailService } from '~/modules/email/email.service';
+
+type Props = {
+  authService?: MockAuthService;
+  databaseService?: DatabaseService;
+  emailService?: MockEmailService;
+};
+
+const mockAuthModule = ({ authService, databaseService, emailService }: Props) => {
+  const providers: Provider[] = [AuthService];
+  const controllers = [AuthController];
+
+  if (databaseService) providers.push(DatabaseService);
+  if (emailService) providers.push(EmailService);
+
+  // Controller의 Unit Test만 고려한 상태. integration test를 진행할 경우 값을 바꿔주어야 함
+  const useController = !!authService && !!emailService;
+
+  const moduleFactory = Test.createTestingModule({
+    providers,
+    controllers: useController ? controllers : [],
+  });
+
+  if (emailService) moduleFactory.overrideProvider(EmailService).useValue(emailService);
+  if (authService) moduleFactory.overrideProvider(AuthService).useValue(authService);
+  if (databaseService) moduleFactory.overrideProvider(DatabaseService).useValue(databaseService);
+
+  return moduleFactory.compile();
+};
+
+export default mockAuthModule;

--- a/packages/backend/src/mock/modules/config.module.ts
+++ b/packages/backend/src/mock/modules/config.module.ts
@@ -1,0 +1,3 @@
+import { ConfigModule } from '@nestjs/config';
+const mockConfigModule = async () => ConfigModule.forFeature(() => process.env);
+export default mockConfigModule;

--- a/packages/backend/src/mock/modules/database.module.ts
+++ b/packages/backend/src/mock/modules/database.module.ts
@@ -1,0 +1,12 @@
+import { Test } from '@nestjs/testing';
+import { DatabaseProvider } from '~/modules/database/database.provider';
+import { DatabaseService } from '~/modules/database/database.service';
+import mockConfigModule from './config.module';
+
+const mockDatabaseModule = async () =>
+  Test.createTestingModule({
+    imports: [await mockConfigModule()],
+    providers: [DatabaseService, DatabaseProvider],
+  }).compile();
+
+export default mockDatabaseModule;

--- a/packages/backend/src/mock/modules/email.module.ts
+++ b/packages/backend/src/mock/modules/email.module.ts
@@ -1,0 +1,11 @@
+import { Test } from '@nestjs/testing';
+import { EmailService } from '~/modules/email/email.service';
+import mockConfigModule from './config.module';
+
+const mockEmailModule = async () =>
+  Test.createTestingModule({
+    imports: [await mockConfigModule()],
+    providers: [EmailService],
+  }).compile();
+
+export default mockEmailModule;

--- a/packages/backend/src/mock/modules/index.ts
+++ b/packages/backend/src/mock/modules/index.ts
@@ -1,0 +1,6 @@
+import mockAuthModule from './auth.module';
+import mockConfigModule from './config.module';
+import mockDatabaseModule from './database.module';
+import mockEmailModule from './email.module';
+
+export { mockAuthModule, mockConfigModule, mockDatabaseModule, mockEmailModule };

--- a/packages/backend/src/modules/auth/auth.controller.spec.ts
+++ b/packages/backend/src/modules/auth/auth.controller.spec.ts
@@ -1,10 +1,13 @@
 import { User } from '@my-task/common';
-import { Test, TestingModule } from '@nestjs/testing';
 import { v4 as uuidv4 } from 'uuid';
-import { MockAuthService, MockEmailService, mockAuthService, mockEmailService } from '~/mock';
-import { EmailService } from '~/modules/email/email.service';
+import {
+  MockAuthService,
+  MockEmailService,
+  mockAuthModule,
+  mockAuthService,
+  mockEmailService,
+} from '~/mock';
 import { AuthController } from './auth.controller';
-import { AuthService } from './auth.service';
 
 describe('AuthController', () => {
   let authService: MockAuthService;
@@ -13,16 +16,7 @@ describe('AuthController', () => {
 
   beforeEach(async () => {
     [authService, emailService] = await Promise.all([mockAuthService(), mockEmailService()]);
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [EmailService, AuthService],
-      controllers: [AuthController],
-    })
-      .overrideProvider(EmailService)
-      .useValue(emailService)
-      .overrideProvider(AuthService)
-      .useValue(authService)
-      .compile();
+    const module = await mockAuthModule({ authService, emailService });
 
     controller = module.get<AuthController>(AuthController);
   });

--- a/packages/backend/src/modules/auth/auth.service.spec.ts
+++ b/packages/backend/src/modules/auth/auth.service.spec.ts
@@ -1,9 +1,7 @@
 import { CreateUserDTO, User } from '@my-task/common';
-import { ConfigModule } from '@nestjs/config';
-import { Test, TestingModule } from '@nestjs/testing';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
-import { DatabaseProvider } from '~/modules/database/database.provider';
+import { mockAuthModule, mockDatabaseModule } from '~/mock';
 import { DatabaseService } from '~/modules/database/database.service';
 import { AuthService } from './auth.service';
 
@@ -11,22 +9,11 @@ describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(async () => {
-    const databaseModule: TestingModule = await Test.createTestingModule({
-      imports: [ConfigModule.forFeature(() => process.env)],
-      providers: [DatabaseService, DatabaseProvider],
-    }).compile();
-
+    const databaseModule = await mockDatabaseModule();
     const databaseService = databaseModule.get<DatabaseService>(DatabaseService);
-
     await databaseService.onModuleInit();
 
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [DatabaseService, AuthService],
-    })
-      .overrideProvider(DatabaseService)
-      .useValue(databaseService)
-      .compile();
-
+    const module = await mockAuthModule({ databaseService });
     service = module.get<AuthService>(AuthService);
   });
 


### PR DESCRIPTION
DESC
----
- 각 테스트에서 사용되는 module mock 코드가 길어 테스트 코드의 가독성을 저하시킴
- 각 module mock을 별개 파일로 분리하여 코드의 가독성과 유지보수성을 향상시킴

Close #112 