### PR TITLE
feat : useMutation의 옵션 타입을 별개 파일로 분리

### DIFF
--- a/packages/frontend/src/api/joinUserConfirm.test.tsx
+++ b/packages/frontend/src/api/joinUserConfirm.test.tsx
@@ -4,7 +4,7 @@ import { RenderHookResult, renderHook, waitFor } from '@testing-library/react';
 import { describe, expectTypeOf } from 'vitest';
 import { BE_ORIGIN } from '~/constants';
 import { server } from '~/mock';
-import createUserConfirm from './joinUserConfirm';
+import joinUserConfirm from './joinUserConfirm';
 
 describe('postJoin', () => {
   let renderedHook: RenderHookResult<
@@ -35,7 +35,7 @@ describe('postJoin', () => {
   afterAll(() => server.close());
 
   beforeEach(() => {
-    renderedHook = renderHook(() => createUserConfirm({}), { wrapper });
+    renderedHook = renderHook(() => joinUserConfirm({}), { wrapper });
   });
 
   afterEach(() => {

--- a/packages/frontend/src/api/joinUserConfirm.ts
+++ b/packages/frontend/src/api/joinUserConfirm.ts
@@ -1,19 +1,13 @@
 import { CreateUserConfirmDTO, User } from '@my-task/common';
 import { useMutation } from '@tanstack/react-query';
+import { MutationOptions } from '~/types';
 import fetchCore from './fetchCore';
 
-type Function = (...args: any[]) => any;
-type MutationOption = {
-  onSuccess?: Function;
-  onError?: Function;
-};
-
-const joinUserConfirm = ({ onSuccess, onError }: MutationOption) =>
+const joinUserConfirm = (options: MutationOptions) =>
   useMutation({
     mutationFn: (body: CreateUserConfirmDTO) =>
       fetchCore<User>('/auth/confirm', { method: 'POST', body }),
-    onSuccess,
-    onError,
+    ...options,
   });
 
 export default joinUserConfirm;

--- a/packages/frontend/src/api/postJoin.ts
+++ b/packages/frontend/src/api/postJoin.ts
@@ -1,19 +1,13 @@
 import { CreateUserDTO } from '@my-task/common';
 import { useMutation } from '@tanstack/react-query';
-import fetchCore from '~/api/fetchCore';
+import { MutationOptions } from '~/types';
+import fetchCore from './fetchCore';
 
-type Function = (...args: any[]) => any;
-type MutationOption = {
-  onSuccess?: Function;
-  onError?: Function;
-};
-
-const postJoin = ({ onSuccess, onError }: MutationOption) =>
+const postJoin = (options: MutationOptions) =>
   useMutation({
     mutationFn: (body: CreateUserDTO) =>
       fetchCore<CreateUserDTO>('/auth', { method: 'POST', body }),
-    onSuccess,
-    onError,
+    ...options,
   });
 
 export default postJoin;

--- a/packages/frontend/src/types/MutationOptions.ts
+++ b/packages/frontend/src/types/MutationOptions.ts
@@ -1,0 +1,3 @@
+import { useMutation } from '@tanstack/react-query';
+type MutationOptions = Parameters<typeof useMutation>[2];
+export default MutationOptions;

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -1,0 +1,2 @@
+import MutationOptions from './MutationOptions';
+export type { MutationOptions };


### PR DESCRIPTION
DESC
----
- useMutation을 이용해 API를 생성할 경우 사용할 parameter 타입을 별개 파일로 분리