### PR TITLE
fix : fetchCore의 타입 오류 수정

### DIFF
--- a/packages/frontend/src/api/fetchCore.ts
+++ b/packages/frontend/src/api/fetchCore.ts
@@ -1,21 +1,22 @@
 import { JsonObject, mergeObjects } from '@my-task/common';
-import { BE_ORIGIN, DEFAULT_FETCH_OPTION } from '~/constants';
+import { BE_ORIGIN, DEFAULT_FETCH_OPTIONS } from '~/constants';
 
-type RequestOption<BodyType extends JsonObject> = Omit<RequestInit, 'body'> & {
+type RequestOption<BodyType extends JsonObject> = JsonObject & {
   body?: BodyType;
 };
 
-const getBody = <Input extends JsonObject>({ body }: RequestOption<Input>) =>
-  body && JSON.stringify(body);
+type BodyObject = { body: string } | {};
+
+const getBody = <Input extends JsonObject>({ body }: RequestOption<Input>): BodyObject =>
+  body ? { body: JSON.stringify(body) } : {};
 
 const fetchCore = async <Output = any, Input extends JsonObject = JsonObject>(
   path: string,
   option: RequestOption<Input> = {},
 ) => {
-  const body = getBody(option);
   const url = new URL(path, BE_ORIGIN);
 
-  const fetchOption = mergeObjects({ body }, option, DEFAULT_FETCH_OPTION) as RequestInit;
+  const fetchOption = mergeObjects(getBody(option), option, DEFAULT_FETCH_OPTIONS) as RequestInit;
 
   const res = await fetch(url.href, fetchOption);
   const data = await res.json();

--- a/packages/frontend/src/constants/defaultFetchOption.ts
+++ b/packages/frontend/src/constants/defaultFetchOption.ts
@@ -1,6 +1,0 @@
-const DEFAULT_FETCH_OPTION: RequestInit = {
-  method: 'GET',
-  headers: { 'Content-Type': 'application/json' },
-};
-
-export default DEFAULT_FETCH_OPTION;

--- a/packages/frontend/src/constants/defaultFetchOptions.ts
+++ b/packages/frontend/src/constants/defaultFetchOptions.ts
@@ -1,0 +1,8 @@
+import { JsonObject } from '@my-task/common';
+
+const DEFAULT_FETCH_OPTIONS: Partial<Pick<JsonObject, keyof RequestInit>> = {
+  method: 'GET',
+  headers: { 'Content-Type': 'application/json' },
+};
+
+export default DEFAULT_FETCH_OPTIONS;

--- a/packages/frontend/src/constants/index.ts
+++ b/packages/frontend/src/constants/index.ts
@@ -1,4 +1,4 @@
 import BE_ORIGIN from '~/constants/backendOrigin';
-import DEFAULT_FETCH_OPTION from '~/constants/defaultFetchOption';
+import DEFAULT_FETCH_OPTIONS from '~/constants/defaultFetchOptions';
 
-export { BE_ORIGIN, DEFAULT_FETCH_OPTION };
+export { BE_ORIGIN, DEFAULT_FETCH_OPTIONS };


### PR DESCRIPTION
DESC
----
- fetchCore에서 사용하는 mergeObject가 JsonObject를 타입으로 받으면서 unedfined가 될 수 있는 body 부분에 타입 오류가 발생함
- getBody 메소드를 body만을 포함하거나 빈 객체를 반환하는 메소드로 바꾸어 JsonObject 타입으로 변경