### PR TITLE
style : 모호한 Backend API 이름을 규칙에 맞춰서 변경

### DIFF
--- a/packages/backend/src/mock/services/auth.service.ts
+++ b/packages/backend/src/mock/services/auth.service.ts
@@ -5,13 +5,13 @@ import { v4 as uuidv4 } from 'uuid';
 const mockAuthService = async () => ({
   uuidToEmail: new Map<string, CreateUserDTO>(),
   emailToUuid: new Map<string, string>(),
-  createUser(dto: CreateUserDTO) {
+  requestJoinUser(dto: CreateUserDTO) {
     const uuid = uuidv4();
     this.uuidToEmail.set(uuid, dto);
     this.emailToUuid.set(dto.email, uuid);
     return uuid;
   },
-  createUserConfirm(dto: CreateUserConfirmDTO) {
+  confirmJoinUser(dto: CreateUserConfirmDTO) {
     if (!this.uuidToEmail.has(dto.uuid))
       throw new BadRequestException('UUID cannot be found: Wrong DTO!');
     const data = this.uuidToEmail.get(dto.uuid) as CreateUserDTO;

--- a/packages/backend/src/modules/auth/auth.controller.spec.ts
+++ b/packages/backend/src/modules/auth/auth.controller.spec.ts
@@ -25,42 +25,40 @@ describe('AuthController', () => {
     expect(controller).toBeDefined();
   });
 
-  describe('createUser', () => {
+  describe('requestJoinUser', () => {
     it('should work', () => {
       const userToAdd = { email: 'create@example.email' };
-      expect(() => controller.createUser(userToAdd)).not.toThrow();
+      expect(() => controller.requestJoinUser(userToAdd)).not.toThrow();
     });
 
     describe('should throw error with', () => {
       it('non-object', () => {
         const data = 'create@example.email';
-        expect(() => controller.createUser(data)).toThrow();
+        expect(() => controller.requestJoinUser(data)).toThrow();
       });
     });
   });
 
-  describe('createUserConfirm', () => {
+  describe('confirmJoinUser', () => {
     it('should work', async () => {
       const userToAdd = { email: 'create@example.email' };
-      const { email } = controller.createUser(userToAdd);
+      const { email } = controller.requestJoinUser(userToAdd);
 
       const uuid = authService.emailToUuid.get(email);
       let user: User;
-      expect((user = await controller.createUserConfirm({ uuid }))).toBeDefined();
+      expect((user = await controller.confirmJoinUser({ uuid }))).toBeDefined();
       expect(user.email).toEqual(userToAdd.email);
     });
 
     describe('should throw error with', () => {
       it('wrong dto', async () => {
         const wrongUUID = 'this is not uuid';
-        await expect(async () =>
-          controller.createUserConfirm({ uuid: wrongUUID }),
-        ).rejects.toThrow();
+        await expect(async () => controller.confirmJoinUser({ uuid: wrongUUID })).rejects.toThrow();
       });
 
       it('non-existing uuid', async () => {
         const uuid = uuidv4();
-        await expect(async () => controller.createUserConfirm({ uuid })).rejects.toThrow();
+        await expect(async () => controller.confirmJoinUser({ uuid })).rejects.toThrow();
       });
     });
   });

--- a/packages/backend/src/modules/auth/auth.controller.ts
+++ b/packages/backend/src/modules/auth/auth.controller.ts
@@ -10,25 +10,25 @@ export class AuthController {
     private readonly emailService: EmailService,
   ) {}
 
-  @Post()
-  createUser(@Body() body: any) {
+  @Post('join/syn')
+  requestJoinUser(@Body() body: any) {
     const result = createUserDTO.safeParse(body);
     if (!result.success) throw new BadRequestException('Wrong DTO: try again!');
     const { data } = result;
 
-    const uuid = this.authService.createUser(data);
+    const uuid = this.authService.requestJoinUser(data);
     // E-Mail 송신은 동기적으로 진행할 필요 없음
     this.emailService.sendJoinEmail(data.email, uuid);
 
     return data;
   }
 
-  @Post('confirm')
-  createUserConfirm(@Body() body: any) {
+  @Post('join/ack')
+  confirmJoinUser(@Body() body: any) {
     const result = createUserConfirmDTO.safeParse(body);
     if (!result.success) throw new BadRequestException('Wrong DTO: try again!');
     const { data } = result;
 
-    return this.authService.createUserConfirm(data);
+    return this.authService.confirmJoinUser(data);
   }
 }

--- a/packages/backend/src/modules/auth/auth.service.spec.ts
+++ b/packages/backend/src/modules/auth/auth.service.spec.ts
@@ -27,10 +27,10 @@ describe('AuthService', () => {
     });
   });
 
-  describe('createUser', () => {
+  describe('requestJoinUser', () => {
     it('should work (validation will be in controller)', () => {
       const userToAdd: CreateUserDTO = { email: 'create@example.email' };
-      const result = service.createUser(userToAdd);
+      const result = service.requestJoinUser(userToAdd);
       const parsedResult = z.string().uuid().safeParse(result);
       expect(parsedResult.success).toEqual(true);
     });
@@ -38,34 +38,34 @@ describe('AuthService', () => {
     describe('should throw error when', () => {
       it('pass same parameter', () => {
         const userToAdd: CreateUserDTO = { email: 'duplicate@example.email' };
-        service.createUser(userToAdd);
-        expect(() => service.createUser(userToAdd)).toThrow();
+        service.requestJoinUser(userToAdd);
+        expect(() => service.requestJoinUser(userToAdd)).toThrow();
       });
     });
   });
 
-  describe('createUserConfirm (validation will be in controller)', () => {
+  describe('confirmJoinUser (validation will be in controller)', () => {
     it('should work', async () => {
       const userToAdd: CreateUserDTO = { email: 'create@example.email' };
-      const uuid = service.createUser(userToAdd);
+      const uuid = service.requestJoinUser(userToAdd);
 
       let createdUser: User = { id: -1, email: '' };
-      expect((createdUser = await service.createUserConfirm({ uuid }))).toBeDefined();
+      expect((createdUser = await service.confirmJoinUser({ uuid }))).toBeDefined();
       expect(createdUser.email).toEqual(userToAdd.email);
     });
 
     describe('should throw error when', () => {
       it('non-existing uuid', async () => {
         const uuid = uuidv4();
-        await expect(async () => service.createUserConfirm({ uuid })).rejects.toThrow();
+        await expect(async () => service.confirmJoinUser({ uuid })).rejects.toThrow();
       });
 
       it('pass same parameter', async () => {
         const userToAdd: CreateUserDTO = { email: 'create@example.email' };
-        const uuid = service.createUser(userToAdd);
+        const uuid = service.requestJoinUser(userToAdd);
 
-        await service.createUserConfirm({ uuid });
-        await expect(async () => service.createUserConfirm({ uuid })).rejects.toThrow();
+        await service.confirmJoinUser({ uuid });
+        await expect(async () => service.confirmJoinUser({ uuid })).rejects.toThrow();
       });
     });
   });

--- a/packages/backend/src/modules/auth/auth.service.ts
+++ b/packages/backend/src/modules/auth/auth.service.ts
@@ -17,7 +17,7 @@ export class AuthService {
     return this.db.select().from(users).execute();
   }
 
-  createUser(dto: CreateUserDTO) {
+  requestJoinUser(dto: CreateUserDTO) {
     if (this.pendingEmail.has(dto.email)) throw new BadRequestException('Emali already exists!');
 
     const uuid = uuidv4();
@@ -27,7 +27,7 @@ export class AuthService {
     return uuid;
   }
 
-  async createUserConfirm(dto: CreateUserConfirmDTO) {
+  async confirmJoinUser(dto: CreateUserConfirmDTO) {
     if (!this.uuidToEmail.has(dto.uuid))
       throw new BadRequestException('UUID cannot be found: Wrong DTO!');
 

--- a/packages/frontend/src/api/confirmJoinUser.ts
+++ b/packages/frontend/src/api/confirmJoinUser.ts
@@ -5,7 +5,7 @@ import fetchCore from './fetchCore';
 
 const confirmJoinUser = (options: MutationOptions<User, CreateUserConfirmDTO>) =>
   useMutation({
-    mutationFn: (body) => fetchCore('/auth/confirm', { method: 'POST', body }),
+    mutationFn: (body) => fetchCore('/auth/join/ack', { method: 'POST', body }),
     ...options,
   });
 

--- a/packages/frontend/src/api/requestJoinUser.ts
+++ b/packages/frontend/src/api/requestJoinUser.ts
@@ -5,7 +5,7 @@ import fetchCore from './fetchCore';
 
 const requestJoinUser = (options: MutationOptions<CreateUserDTO, CreateUserDTO>) =>
   useMutation({
-    mutationFn: (body) => fetchCore('/auth', { method: 'POST', body }),
+    mutationFn: (body) => fetchCore('/auth/join/syn', { method: 'POST', body }),
     ...options,
   });
 

--- a/packages/frontend/src/mock/handlers.ts
+++ b/packages/frontend/src/mock/handlers.ts
@@ -14,7 +14,7 @@ export const handlers = [
     res(ctx.status(400), ctx.json({ errorMessage: 'Error thrown for unknown reason.' })),
   ),
 
-  rest.post(mockDir('/auth'), async (req, res, ctx) => {
+  rest.post(mockDir('/auth/join/syn'), async (req, res, ctx) => {
     const body = await req.json();
 
     ctx.delay();
@@ -27,7 +27,7 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(data));
   }),
 
-  rest.post(mockDir('/auth/confirm'), async (req, res, ctx) => {
+  rest.post(mockDir('/auth/join/ack'), async (req, res, ctx) => {
     const body = await req.json();
 
     ctx.delay();


### PR DESCRIPTION
DESC
----
- 특별한 원칙 없이 정해진 Backend API 이름을 통일감 있게 변경
- Backend controller/service의 메소드 이름을 Frontend의 API 이름과 같게끔 변경