### PR TITLE
feat : 회원가입 시 사용자의 개인 그룹을 생성

### DIFF
--- a/packages/backend/src/mock/modules/auth.module.ts
+++ b/packages/backend/src/mock/modules/auth.module.ts
@@ -1,23 +1,26 @@
 import { Provider } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { MockAuthService, MockEmailService } from '~/mock';
+import { MockAuthService, MockEmailService, MockGroupService } from '~/mock/services';
 import { AuthController } from '~/modules/auth/auth.controller';
 import { AuthService } from '~/modules/auth/auth.service';
 import { DatabaseService } from '~/modules/database/database.service';
 import { EmailService } from '~/modules/email/email.service';
+import { GroupService } from '~/modules/group/group.service';
 
 type Props = {
   authService?: MockAuthService;
   databaseService?: DatabaseService;
   emailService?: MockEmailService;
+  groupService?: MockGroupService;
 };
 
-const mockAuthModule = ({ authService, databaseService, emailService }: Props) => {
+const mockAuthModule = ({ authService, databaseService, emailService, groupService }: Props) => {
   const providers: Provider[] = [AuthService];
   const controllers = [AuthController];
 
   if (databaseService) providers.push(DatabaseService);
   if (emailService) providers.push(EmailService);
+  if (groupService) providers.push(GroupService);
 
   // Controller의 Unit Test만 고려한 상태. integration test를 진행할 경우 값을 바꿔주어야 함
   const useController = !!authService && !!emailService;
@@ -30,6 +33,7 @@ const mockAuthModule = ({ authService, databaseService, emailService }: Props) =
   if (emailService) moduleFactory.overrideProvider(EmailService).useValue(emailService);
   if (authService) moduleFactory.overrideProvider(AuthService).useValue(authService);
   if (databaseService) moduleFactory.overrideProvider(DatabaseService).useValue(databaseService);
+  if (groupService) moduleFactory.overrideProvider(GroupService).useValue(groupService);
 
   return moduleFactory.compile();
 };

--- a/packages/backend/src/mock/services/group.service.ts
+++ b/packages/backend/src/mock/services/group.service.ts
@@ -1,0 +1,21 @@
+import { Group, User } from '@my-task/common';
+
+const mockGroupService = async () => ({
+  groups: new Map<number, Group[]>(),
+  async createGroup(creator: User, name: string) {
+    const group: Group = {
+      id: Math.floor(Math.random() * 10),
+      name,
+    };
+    this.groups.set(creator.id, (this.groups.get(creator.id) || []).concat([group]));
+    return group;
+  },
+  async findGroupByMember(member: User) {
+    return this.groups.get(member.id) ?? [];
+  },
+});
+
+type MockGroupService = Awaited<ReturnType<typeof mockGroupService>>;
+
+export { mockGroupService };
+export type { MockGroupService };

--- a/packages/backend/src/mock/services/index.ts
+++ b/packages/backend/src/mock/services/index.ts
@@ -1,2 +1,3 @@
 export * from './auth.service';
 export * from './email.service';
+export * from './group.service';

--- a/packages/backend/src/modules/auth/auth.controller.spec.ts
+++ b/packages/backend/src/modules/auth/auth.controller.spec.ts
@@ -3,20 +3,27 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   MockAuthService,
   MockEmailService,
+  MockGroupService,
   mockAuthModule,
   mockAuthService,
   mockEmailService,
+  mockGroupService,
 } from '~/mock';
 import { AuthController } from './auth.controller';
 
 describe('AuthController', () => {
   let authService: MockAuthService;
   let emailService: MockEmailService;
+  let groupService: MockGroupService;
   let controller: AuthController;
 
   beforeEach(async () => {
-    [authService, emailService] = await Promise.all([mockAuthService(), mockEmailService()]);
-    const module = await mockAuthModule({ authService, emailService });
+    [authService, emailService, groupService] = await Promise.all([
+      mockAuthService(),
+      mockEmailService(),
+      mockGroupService(),
+    ]);
+    const module = await mockAuthModule({ authService, emailService, groupService });
 
     controller = module.get<AuthController>(AuthController);
   });
@@ -48,6 +55,7 @@ describe('AuthController', () => {
       let user: User;
       expect((user = await controller.confirmJoinUser({ uuid }))).toBeDefined();
       expect(user.email).toEqual(userToAdd.email);
+      expect((await groupService.findGroupByMember(user)).length).toBeGreaterThan(0);
     });
 
     describe('should throw error with', () => {

--- a/packages/backend/src/modules/auth/auth.module.ts
+++ b/packages/backend/src/modules/auth/auth.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { GroupModule } from '~/modules/group/group.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 
 @Module({
+  imports: [GroupModule],
   providers: [AuthService],
   controllers: [AuthController],
 })


### PR DESCRIPTION
DESC
----
- 회원가입 시 사용자의 개인 그룹을 생성

TEST
----
1. 새로운 e-mail로 회원가입 진행
2. DB의 group 테이블과 member 테이블에 정상적인 레코드가 생성되었는지 확인