### PR TITLE
refact : fetch 구조 변경

### DIFF
--- a/packages/frontend/src/api/confirmJoinUser.ts
+++ b/packages/frontend/src/api/confirmJoinUser.ts
@@ -1,11 +1,11 @@
 import { ConfirmJoinUserDTO, User } from '@my-task/common';
 import { useMutation } from '@tanstack/react-query';
 import { MutationOptions } from '~/types';
-import fetchCore from './fetchCore';
+import _fetch from './core';
 
 const confirmJoinUser = (options: MutationOptions<User, ConfirmJoinUserDTO>) =>
   useMutation({
-    mutationFn: (body) => fetchCore('/auth/join/ack', { method: 'POST', body }),
+    mutationFn: (body) => _fetch('/auth/join/ack', { method: 'POST', body }),
     ...options,
   });
 

--- a/packages/frontend/src/api/core/index.test.ts
+++ b/packages/frontend/src/api/core/index.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect } from 'vitest';
-import fetchCore from '~/api/fetchCore';
 import { BE_ORIGIN } from '~/constants';
 import { server } from '~/mock';
+import _fetch from '.';
 
-describe('fetchCore', () => {
+describe('_fetch', () => {
   beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
   // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
   beforeEach(() => location.replace(BE_ORIGIN));
@@ -12,13 +12,13 @@ describe('fetchCore', () => {
 
   describe('should work with', () => {
     it('no body', async () => {
-      const result = await fetchCore('/');
+      const result = await _fetch('/');
       expect(result).toStrictEqual({ foo: 'bar' });
     });
 
     it('body', async () => {
       const body = { date: new Date().getTime() };
-      const result = await fetchCore('/', { method: 'POST', body });
+      const result = await _fetch('/', { method: 'POST', body });
       expect(result).toStrictEqual(body);
     });
   });
@@ -26,17 +26,17 @@ describe('fetchCore', () => {
   describe('should throw error when', () => {
     it('invalid path', () => {
       const path = '/invalid/path';
-      expect(async () => fetchCore(path)).rejects.toThrow();
+      expect(async () => _fetch(path)).rejects.toThrow();
     });
 
     it('invalid method', () => {
       const path = '/';
-      expect(async () => fetchCore(path, { method: 'WRONG_METHOD' })).rejects.toThrow();
+      expect(async () => _fetch(path, { method: 'WRONG_METHOD' })).rejects.toThrow();
     });
 
     it('error thrown in server', () => {
       const path = '/error';
-      expect(async () => fetchCore(path)).rejects.toThrow();
+      expect(async () => _fetch(path)).rejects.toThrow();
     });
   });
 });

--- a/packages/frontend/src/api/core/index.ts
+++ b/packages/frontend/src/api/core/index.ts
@@ -10,7 +10,7 @@ type BodyObject = { body: string } | {};
 const getBody = <Input extends JsonObject>({ body }: RequestOption<Input>): BodyObject =>
   body ? { body: JSON.stringify(body) } : {};
 
-const fetchCore = async <Output = any, Input extends JsonObject = JsonObject>(
+const _fetch = async <Output = any, Input extends JsonObject = JsonObject>(
   path: string,
   option: RequestOption<Input> = {},
 ) => {
@@ -25,4 +25,4 @@ const fetchCore = async <Output = any, Input extends JsonObject = JsonObject>(
   return data as Output;
 };
 
-export default fetchCore;
+export default _fetch;

--- a/packages/frontend/src/api/getConnectionTest.ts
+++ b/packages/frontend/src/api/getConnectionTest.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import fetchCore from '~/api/fetchCore';
+import _fetch from './core';
 
 const getConnectionTest = () =>
   useQuery({
     queryKey: ['Connection Test'],
-    queryFn: () => fetchCore(''),
+    queryFn: () => _fetch(''),
   });
 
 export default getConnectionTest;

--- a/packages/frontend/src/api/requestJoinUser.ts
+++ b/packages/frontend/src/api/requestJoinUser.ts
@@ -1,11 +1,11 @@
 import { RequestJoinUserDTO } from '@my-task/common';
 import { useMutation } from '@tanstack/react-query';
 import { MutationOptions } from '~/types';
-import fetchCore from './fetchCore';
+import _fetch from './core';
 
 const requestJoinUser = (options: MutationOptions<RequestJoinUserDTO, RequestJoinUserDTO>) =>
   useMutation({
-    mutationFn: (body) => fetchCore('/auth/join/syn', { method: 'POST', body }),
+    mutationFn: (body) => _fetch('/auth/join/syn', { method: 'POST', body }),
     ...options,
   });
 


### PR DESCRIPTION
DESC
----
- `fetchCore`라는 모호한 이름을 `_fetch`로 바꾸어 역할과 private함을 강조
- `_fetch`의 위치를 React Query와 같은 위치가 아닌 서브 디렉토리 `core`로 이동

Close #154 