### PR TITLE
test : signup 모듈로 테스트 코드 이동

### DIFF
--- a/packages/backend/src/mock/modules/index.ts
+++ b/packages/backend/src/mock/modules/index.ts
@@ -1,7 +1,7 @@
-import mockAuthModule from './auth.module';
 import mockConfigModule from './config.module';
 import mockDatabaseModule from './database.module';
 import mockEmailModule from './email.module';
 import mockGroupModule from './group.module';
+import mockSignupModule from './signup.module';
 
-export { mockAuthModule, mockConfigModule, mockDatabaseModule, mockEmailModule, mockGroupModule };
+export { mockSignupModule, mockConfigModule, mockDatabaseModule, mockEmailModule, mockGroupModule };

--- a/packages/backend/src/mock/modules/signup.module.ts
+++ b/packages/backend/src/mock/modules/signup.module.ts
@@ -1,29 +1,34 @@
 import { Provider } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { MockAuthService, MockEmailService, MockGroupService } from '~/mock/services';
-import { AuthController } from '~/modules/auth/auth.controller';
-import { AuthService } from '~/modules/auth/auth.service';
+import { MockEmailService, MockGroupService, MockSignupService } from '~/mock/services';
+import { SignupController } from '~/modules/auth/signup/signup.controller';
+import { SignupService } from '~/modules/auth/signup/signup.service';
 import { DatabaseService } from '~/modules/database/database.service';
 import { EmailService } from '~/modules/email/email.service';
 import { GroupService } from '~/modules/group/group.service';
 
 type Props = {
-  authService?: MockAuthService;
+  signupService?: MockSignupService;
   databaseService?: DatabaseService;
   emailService?: MockEmailService;
   groupService?: MockGroupService;
 };
 
-const mockAuthModule = ({ authService, databaseService, emailService, groupService }: Props) => {
-  const providers: Provider[] = [AuthService];
-  const controllers = [AuthController];
+const mockSignupModule = ({
+  signupService,
+  databaseService,
+  emailService,
+  groupService,
+}: Props) => {
+  const providers: Provider[] = [SignupService];
+  const controllers = [SignupController];
 
   if (databaseService) providers.push(DatabaseService);
   if (emailService) providers.push(EmailService);
   if (groupService) providers.push(GroupService);
 
   // Controller의 Unit Test만 고려한 상태. integration test를 진행할 경우 값을 바꿔주어야 함
-  const useController = !!authService && !!emailService;
+  const useController = !!signupService && !!emailService;
 
   const moduleFactory = Test.createTestingModule({
     providers,
@@ -31,11 +36,11 @@ const mockAuthModule = ({ authService, databaseService, emailService, groupServi
   });
 
   if (emailService) moduleFactory.overrideProvider(EmailService).useValue(emailService);
-  if (authService) moduleFactory.overrideProvider(AuthService).useValue(authService);
+  if (signupService) moduleFactory.overrideProvider(SignupService).useValue(signupService);
   if (databaseService) moduleFactory.overrideProvider(DatabaseService).useValue(databaseService);
   if (groupService) moduleFactory.overrideProvider(GroupService).useValue(groupService);
 
   return moduleFactory.compile();
 };
 
-export default mockAuthModule;
+export default mockSignupModule;

--- a/packages/backend/src/mock/services/index.ts
+++ b/packages/backend/src/mock/services/index.ts
@@ -1,3 +1,3 @@
-export * from './auth.service';
 export * from './email.service';
 export * from './group.service';
+export * from './signup.service';

--- a/packages/backend/src/mock/services/signup.service.ts
+++ b/packages/backend/src/mock/services/signup.service.ts
@@ -2,7 +2,7 @@ import { ConfirmJoinUserDTO, RequestJoinUserDTO, User } from '@my-task/common';
 import { BadRequestException } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
 
-const mockAuthService = async () => ({
+const mockSignupService = async () => ({
   uuidToEmail: new Map<string, RequestJoinUserDTO>(),
   emailToUuid: new Map<string, string>(),
   requestJoinUser(dto: RequestJoinUserDTO) {
@@ -21,7 +21,7 @@ const mockAuthService = async () => ({
   },
 });
 
-type MockAuthService = Awaited<ReturnType<typeof mockAuthService>>;
+type MockSignupService = Awaited<ReturnType<typeof mockSignupService>>;
 
-export { mockAuthService };
-export type { MockAuthService };
+export { mockSignupService };
+export type { MockSignupService };

--- a/packages/backend/src/modules/auth/signup/signup.controller.spec.ts
+++ b/packages/backend/src/modules/auth/signup/signup.controller.spec.ts
@@ -1,31 +1,31 @@
 import { User } from '@my-task/common';
 import { v4 as uuidv4 } from 'uuid';
 import {
-  MockAuthService,
   MockEmailService,
   MockGroupService,
-  mockAuthModule,
-  mockAuthService,
+  MockSignupService,
   mockEmailService,
   mockGroupService,
+  mockSignupModule,
+  mockSignupService,
 } from '~/mock';
-import { AuthController } from './auth.controller';
+import { SignupController } from './signup.controller';
 
-describe('AuthController', () => {
-  let authService: MockAuthService;
+describe('SignupController', () => {
+  let signupService: MockSignupService;
   let emailService: MockEmailService;
   let groupService: MockGroupService;
-  let controller: AuthController;
+  let controller: SignupController;
 
   beforeEach(async () => {
-    [authService, emailService, groupService] = await Promise.all([
-      mockAuthService(),
+    [signupService, emailService, groupService] = await Promise.all([
+      mockSignupService(),
       mockEmailService(),
       mockGroupService(),
     ]);
-    const module = await mockAuthModule({ authService, emailService, groupService });
+    const module = await mockSignupModule({ signupService, emailService, groupService });
 
-    controller = module.get<AuthController>(AuthController);
+    controller = module.get<SignupController>(SignupController);
   });
 
   it('should be defined', () => {
@@ -51,7 +51,7 @@ describe('AuthController', () => {
       const userToAdd = { email: 'create@example.email' };
       const { email } = controller.requestJoinUser(userToAdd);
 
-      const uuid = authService.emailToUuid.get(email);
+      const uuid = signupService.emailToUuid.get(email);
       let user: User;
       expect((user = await controller.confirmJoinUser({ uuid }))).toBeDefined();
       expect(user.email).toEqual(userToAdd.email);

--- a/packages/backend/src/modules/auth/signup/signup.service.spec.ts
+++ b/packages/backend/src/modules/auth/signup/signup.service.spec.ts
@@ -1,20 +1,20 @@
 import { RequestJoinUserDTO, User } from '@my-task/common';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
-import { mockAuthModule, mockDatabaseModule } from '~/mock';
+import { mockDatabaseModule, mockSignupModule } from '~/mock';
 import { DatabaseService } from '~/modules/database/database.service';
-import { AuthService } from './auth.service';
+import { SignupService } from './signup.service';
 
-describe('AuthService', () => {
-  let service: AuthService;
+describe('SignupService', () => {
+  let service: SignupService;
 
   beforeEach(async () => {
     const databaseModule = await mockDatabaseModule();
     const databaseService = databaseModule.get<DatabaseService>(DatabaseService);
     await databaseService.onModuleInit();
 
-    const module = await mockAuthModule({ databaseService });
-    service = module.get<AuthService>(AuthService);
+    const module = await mockSignupModule({ databaseService });
+    service = module.get<SignupService>(SignupService);
   });
 
   it('should be defined', () => {


### PR DESCRIPTION
DESC
----
- 테스트에 사용하는 mock 모듈 및 서비스의 이름을 auth에서 signup으로 변경
- 기존 auth 모듈의 테스트 코드를 signup 모듈로 이동

NOTE
----
- 아직 새로운 mockAuthModule을 만들 필요가 없으므로 Auth 모듈의 테스트 코드는 제거함