### PR TITLE
test : signup 모듈로 테스트 코드 이동

### DIFF
--- a/packages/backend/src/mock/modules/index.ts
+++ b/packages/backend/src/mock/modules/index.ts
@@ -1,7 +1,7 @@
-import mockAuthModule from './auth.module';
 import mockConfigModule from './config.module';
 import mockDatabaseModule from './database.module';
 import mockEmailModule from './email.module';
 import mockGroupModule from './group.module';
+import mockSignUpModule from './signup.module';
 
-export { mockAuthModule, mockConfigModule, mockDatabaseModule, mockEmailModule, mockGroupModule };
+export { mockSignUpModule, mockConfigModule, mockDatabaseModule, mockEmailModule, mockGroupModule };

--- a/packages/backend/src/mock/modules/signup.module.ts
+++ b/packages/backend/src/mock/modules/signup.module.ts
@@ -1,29 +1,34 @@
 import { Provider } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { MockAuthService, MockEmailService, MockGroupService } from '~/mock/services';
-import { AuthController } from '~/modules/auth/auth.controller';
-import { AuthService } from '~/modules/auth/auth.service';
+import { MockEmailService, MockGroupService, MockSignUpService } from '~/mock/services';
+import { SignUpController } from '~/modules/auth/signup/signup.controller';
+import { SignUpService } from '~/modules/auth/signup/signup.service';
 import { DatabaseService } from '~/modules/database/database.service';
 import { EmailService } from '~/modules/email/email.service';
 import { GroupService } from '~/modules/group/group.service';
 
 type Props = {
-  authService?: MockAuthService;
+  signupService?: MockSignUpService;
   databaseService?: DatabaseService;
   emailService?: MockEmailService;
   groupService?: MockGroupService;
 };
 
-const mockAuthModule = ({ authService, databaseService, emailService, groupService }: Props) => {
-  const providers: Provider[] = [AuthService];
-  const controllers = [AuthController];
+const mockSignUpModule = ({
+  signupService,
+  databaseService,
+  emailService,
+  groupService,
+}: Props) => {
+  const providers: Provider[] = [SignUpService];
+  const controllers = [SignUpController];
 
   if (databaseService) providers.push(DatabaseService);
   if (emailService) providers.push(EmailService);
   if (groupService) providers.push(GroupService);
 
   // Controller의 Unit Test만 고려한 상태. integration test를 진행할 경우 값을 바꿔주어야 함
-  const useController = !!authService && !!emailService;
+  const useController = !!signupService && !!emailService;
 
   const moduleFactory = Test.createTestingModule({
     providers,
@@ -31,11 +36,11 @@ const mockAuthModule = ({ authService, databaseService, emailService, groupServi
   });
 
   if (emailService) moduleFactory.overrideProvider(EmailService).useValue(emailService);
-  if (authService) moduleFactory.overrideProvider(AuthService).useValue(authService);
+  if (signupService) moduleFactory.overrideProvider(SignUpService).useValue(signupService);
   if (databaseService) moduleFactory.overrideProvider(DatabaseService).useValue(databaseService);
   if (groupService) moduleFactory.overrideProvider(GroupService).useValue(groupService);
 
   return moduleFactory.compile();
 };
 
-export default mockAuthModule;
+export default mockSignUpModule;

--- a/packages/backend/src/mock/services/index.ts
+++ b/packages/backend/src/mock/services/index.ts
@@ -1,3 +1,3 @@
-export * from './auth.service';
 export * from './email.service';
 export * from './group.service';
+export * from './signup.service';

--- a/packages/backend/src/mock/services/signup.service.ts
+++ b/packages/backend/src/mock/services/signup.service.ts
@@ -2,16 +2,16 @@ import { ConfirmJoinUserDTO, RequestJoinUserDTO, User } from '@my-task/common';
 import { BadRequestException } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
 
-const mockAuthService = async () => ({
+const mockSignUpService = async () => ({
   uuidToEmail: new Map<string, RequestJoinUserDTO>(),
   emailToUuid: new Map<string, string>(),
-  requestJoinUser(dto: RequestJoinUserDTO) {
+  requestSignUpUser(dto: RequestJoinUserDTO) {
     const uuid = uuidv4();
     this.uuidToEmail.set(uuid, dto);
     this.emailToUuid.set(dto.email, uuid);
     return uuid;
   },
-  confirmJoinUser(dto: ConfirmJoinUserDTO) {
+  confirmSignUpUser(dto: ConfirmJoinUserDTO) {
     if (!this.uuidToEmail.has(dto.uuid))
       throw new BadRequestException('UUID cannot be found: Wrong DTO!');
     const data = this.uuidToEmail.get(dto.uuid) as RequestJoinUserDTO;
@@ -21,7 +21,7 @@ const mockAuthService = async () => ({
   },
 });
 
-type MockAuthService = Awaited<ReturnType<typeof mockAuthService>>;
+type MockSignUpService = Awaited<ReturnType<typeof mockSignUpService>>;
 
-export { mockAuthService };
-export type { MockAuthService };
+export { mockSignUpService };
+export type { MockSignUpService };

--- a/packages/backend/src/modules/auth/signup/signup.controller.spec.ts
+++ b/packages/backend/src/modules/auth/signup/signup.controller.spec.ts
@@ -1,59 +1,59 @@
 import { User } from '@my-task/common';
 import { v4 as uuidv4 } from 'uuid';
 import {
-  MockAuthService,
   MockEmailService,
   MockGroupService,
-  mockAuthModule,
-  mockAuthService,
+  MockSignUpService,
   mockEmailService,
   mockGroupService,
+  mockSignUpModule,
+  mockSignUpService,
 } from '~/mock';
-import { AuthController } from './auth.controller';
+import { SignUpController } from './signup.controller';
 
-describe('AuthController', () => {
-  let authService: MockAuthService;
+describe('SignUpController', () => {
+  let signupService: MockSignUpService;
   let emailService: MockEmailService;
   let groupService: MockGroupService;
-  let controller: AuthController;
+  let controller: SignUpController;
 
   beforeEach(async () => {
-    [authService, emailService, groupService] = await Promise.all([
-      mockAuthService(),
+    [signupService, emailService, groupService] = await Promise.all([
+      mockSignUpService(),
       mockEmailService(),
       mockGroupService(),
     ]);
-    const module = await mockAuthModule({ authService, emailService, groupService });
+    const module = await mockSignUpModule({ signupService, emailService, groupService });
 
-    controller = module.get<AuthController>(AuthController);
+    controller = module.get<SignUpController>(SignUpController);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
 
-  describe('requestJoinUser', () => {
+  describe('requestSignUpUser', () => {
     it('should work', () => {
       const userToAdd = { email: 'create@example.email' };
-      expect(() => controller.requestJoinUser(userToAdd)).not.toThrow();
+      expect(() => controller.requestSignUpUser(userToAdd)).not.toThrow();
     });
 
     describe('should throw error with', () => {
       it('non-object', () => {
         const data = 'create@example.email';
-        expect(() => controller.requestJoinUser(data)).toThrow();
+        expect(() => controller.requestSignUpUser(data)).toThrow();
       });
     });
   });
 
-  describe('confirmJoinUser', () => {
+  describe('confirmSignUpUser', () => {
     it('should work', async () => {
       const userToAdd = { email: 'create@example.email' };
-      const { email } = controller.requestJoinUser(userToAdd);
+      const { email } = controller.requestSignUpUser(userToAdd);
 
-      const uuid = authService.emailToUuid.get(email);
+      const uuid = signupService.emailToUuid.get(email);
       let user: User;
-      expect((user = await controller.confirmJoinUser({ uuid }))).toBeDefined();
+      expect((user = await controller.confirmSignUpUser({ uuid }))).toBeDefined();
       expect(user.email).toEqual(userToAdd.email);
       expect((await groupService.findGroupByMember(user)).length).toBeGreaterThan(0);
     });
@@ -61,12 +61,14 @@ describe('AuthController', () => {
     describe('should throw error with', () => {
       it('wrong dto', async () => {
         const wrongUUID = 'this is not uuid';
-        await expect(async () => controller.confirmJoinUser({ uuid: wrongUUID })).rejects.toThrow();
+        await expect(async () =>
+          controller.confirmSignUpUser({ uuid: wrongUUID }),
+        ).rejects.toThrow();
       });
 
       it('non-existing uuid', async () => {
         const uuid = uuidv4();
-        await expect(async () => controller.confirmJoinUser({ uuid })).rejects.toThrow();
+        await expect(async () => controller.confirmSignUpUser({ uuid })).rejects.toThrow();
       });
     });
   });

--- a/packages/backend/src/modules/auth/signup/signup.service.spec.ts
+++ b/packages/backend/src/modules/auth/signup/signup.service.spec.ts
@@ -1,20 +1,20 @@
 import { RequestJoinUserDTO, User } from '@my-task/common';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
-import { mockAuthModule, mockDatabaseModule } from '~/mock';
+import { mockDatabaseModule, mockSignUpModule } from '~/mock';
 import { DatabaseService } from '~/modules/database/database.service';
-import { AuthService } from './auth.service';
+import { SignUpService } from './signup.service';
 
-describe('AuthService', () => {
-  let service: AuthService;
+describe('SignUpService', () => {
+  let service: SignUpService;
 
   beforeEach(async () => {
     const databaseModule = await mockDatabaseModule();
     const databaseService = databaseModule.get<DatabaseService>(DatabaseService);
     await databaseService.onModuleInit();
 
-    const module = await mockAuthModule({ databaseService });
-    service = module.get<AuthService>(AuthService);
+    const module = await mockSignUpModule({ databaseService });
+    service = module.get<SignUpService>(SignUpService);
   });
 
   it('should be defined', () => {
@@ -27,10 +27,10 @@ describe('AuthService', () => {
     });
   });
 
-  describe('requestJoinUser', () => {
+  describe('requestSignUpUser', () => {
     it('should work (validation will be in controller)', () => {
       const userToAdd: RequestJoinUserDTO = { email: 'create@example.email' };
-      const result = service.requestJoinUser(userToAdd);
+      const result = service.requestSignUpUser(userToAdd);
       const parsedResult = z.string().uuid().safeParse(result);
       expect(parsedResult.success).toEqual(true);
     });
@@ -38,34 +38,34 @@ describe('AuthService', () => {
     describe('should throw error when', () => {
       it('pass same parameter', () => {
         const userToAdd: RequestJoinUserDTO = { email: 'duplicate@example.email' };
-        service.requestJoinUser(userToAdd);
-        expect(() => service.requestJoinUser(userToAdd)).toThrow();
+        service.requestSignUpUser(userToAdd);
+        expect(() => service.requestSignUpUser(userToAdd)).toThrow();
       });
     });
   });
 
-  describe('confirmJoinUser (validation will be in controller)', () => {
+  describe('confirmSignUpUser (validation will be in controller)', () => {
     it('should work', async () => {
       const userToAdd: RequestJoinUserDTO = { email: 'create@example.email' };
-      const uuid = service.requestJoinUser(userToAdd);
+      const uuid = service.requestSignUpUser(userToAdd);
 
       let createdUser: User = { id: -1, email: '' };
-      expect((createdUser = await service.confirmJoinUser({ uuid }))).toBeDefined();
+      expect((createdUser = await service.confirmSignUpUser({ uuid }))).toBeDefined();
       expect(createdUser.email).toEqual(userToAdd.email);
     });
 
     describe('should throw error when', () => {
       it('non-existing uuid', async () => {
         const uuid = uuidv4();
-        await expect(async () => service.confirmJoinUser({ uuid })).rejects.toThrow();
+        await expect(async () => service.confirmSignUpUser({ uuid })).rejects.toThrow();
       });
 
       it('pass same parameter', async () => {
         const userToAdd: RequestJoinUserDTO = { email: 'create@example.email' };
-        const uuid = service.requestJoinUser(userToAdd);
+        const uuid = service.requestSignUpUser(userToAdd);
 
-        await service.confirmJoinUser({ uuid });
-        await expect(async () => service.confirmJoinUser({ uuid })).rejects.toThrow();
+        await service.confirmSignUpUser({ uuid });
+        await expect(async () => service.confirmSignUpUser({ uuid })).rejects.toThrow();
       });
     });
   });


### PR DESCRIPTION
DESC
----
- 테스트에 사용하는 mock 모듈 및 서비스의 이름을 auth에서 signup으로 변경
- 기존 auth 모듈의 테스트 코드를 signup 모듈로 이동

NOTE
----
- 아직 새로운 mockAuthModule을 만들 필요가 없으므로 Auth 모듈의 테스트 코드는 제거함