### PR TITLE
feat : sendJoinEmail 메소드를 SignUpController로 이동

### DIFF
--- a/packages/backend/src/mock/modules/signup.module.ts
+++ b/packages/backend/src/mock/modules/signup.module.ts
@@ -1,5 +1,6 @@
 import { Provider } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import mockConfigModule from '~/mock/modules/config.module';
 import { MockEmailService, MockGroupService, MockSignUpService } from '~/mock/services';
 import { SignUpController } from '~/modules/auth/signup/signup.controller';
 import { SignUpService } from '~/modules/auth/signup/signup.service';
@@ -14,7 +15,7 @@ type Props = {
   groupService?: MockGroupService;
 };
 
-const mockSignUpModule = ({
+const mockSignUpModule = async ({
   signupService,
   databaseService,
   emailService,
@@ -31,6 +32,7 @@ const mockSignUpModule = ({
   const useController = !!signupService && !!emailService;
 
   const moduleFactory = Test.createTestingModule({
+    imports: [await mockConfigModule()],
     providers,
     controllers: useController ? controllers : [],
   });

--- a/packages/backend/src/mock/services/email.service.ts
+++ b/packages/backend/src/mock/services/email.service.ts
@@ -1,6 +1,6 @@
 const mockEmailService = async () => ({
-  sendSignUpEmail: (target: string, uuid: string) =>
-    new Promise((resolve) => resolve({ target, uuid })),
+  sendEmail: (receiver: string, title: string, body: string) =>
+    new Promise((resolve) => resolve({ receiver, title, body })),
 });
 
 type MockEmailService = Awaited<ReturnType<typeof mockEmailService>>;

--- a/packages/backend/src/modules/auth/signup/signup.controller.ts
+++ b/packages/backend/src/modules/auth/signup/signup.controller.ts
@@ -1,16 +1,32 @@
 import { confirmSignUpDTOSchema, requestSignUpDTOSchema } from '@my-task/common';
 import { BadRequestException, Body, Controller, Post } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { EmailService } from '~/modules/email/email.service';
 import { GroupService } from '~/modules/group/group.service';
+import { Env } from '~/types';
 import { SignUpService } from './signup.service';
 
 @Controller('signup')
 export class SignUpController {
+  private readonly FE_ORIGIN: string;
+
   constructor(
     private readonly signupService: SignUpService,
-    private readonly emailService: EmailService,
     private readonly groupService: GroupService,
-  ) {}
+    private readonly emailService: EmailService,
+    configService: ConfigService<Env>,
+  ) {
+    const { HOST, FE_PORT } = configService.getOrThrow<Env['NETWORK']>('NETWORK');
+    this.FE_ORIGIN = `http://${HOST}:${FE_PORT}`;
+  }
+
+  private sendSignUpEmail(receiver: string, uuid: string) {
+    return this.emailService.sendEmail(
+      receiver,
+      '[MyTask] Please verify your E-Mail!',
+      `Click <a href="${this.FE_ORIGIN}/welcome/${uuid}">HERE</a> to verify your E-Mail!`,
+    );
+  }
 
   @Post('syn')
   requestSignUpUser(@Body() body: any) {
@@ -20,7 +36,7 @@ export class SignUpController {
 
     const uuid = this.signupService.requestSignUpUser(data);
     // E-Mail 송신은 동기적으로 진행할 필요 없음
-    this.emailService.sendSignUpEmail(data.email, uuid);
+    this.sendSignUpEmail(data.email, uuid);
 
     return data;
   }

--- a/packages/backend/src/modules/email/email.service.spec.ts
+++ b/packages/backend/src/modules/email/email.service.spec.ts
@@ -1,5 +1,4 @@
 import SMTPPool from 'nodemailer/lib/smtp-pool';
-import { v4 as uuidv4 } from 'uuid';
 import { mockEmailModule } from '~/mock';
 import { EmailService } from './email.service';
 
@@ -36,15 +35,6 @@ describe('EmailService', () => {
           async () => await service.sendEmail('', 'test', '<div>test123</div>'),
         ).rejects.toThrow();
       });
-    });
-  });
-
-  describe('sendSignUpEmail', () => {
-    it('should work', async () => {
-      let result: SMTPPool.SentMessageInfo;
-      expect((result = await service.sendSignUpEmail(receiver, uuidv4()))).toBeDefined();
-      expect(result.accepted.length).toEqual(1);
-      expect(result.rejected.length).toEqual(0);
     });
   });
 });

--- a/packages/backend/src/modules/email/email.service.ts
+++ b/packages/backend/src/modules/email/email.service.ts
@@ -40,15 +40,4 @@ export class EmailService implements OnModuleDestroy {
       this.transport.sendMail(mailOption, (err, info) => (err ? reject(err) : resolve(info)));
     });
   }
-
-  sendSignUpEmail(receiver: string, uuid: string) {
-    const { HOST, FE_PORT } = this.configService.getOrThrow<Env['NETWORK']>('NETWORK');
-    const FE_ORIGIN = `http://${HOST}:${FE_PORT}`;
-
-    return this.sendEmail(
-      receiver,
-      '[MyTask] Please verify your E-Mail!',
-      `Click <a href="${FE_ORIGIN}/welcome/${uuid}">HERE</a> to verify your E-Mail!`,
-    );
-  }
 }


### PR DESCRIPTION
DESC
----
- 모든 E-Mail 전송 기능을 emailService에 구현한다면 emailService가 매우 복잡해짐
- 보내고 싶은 종류의 E-Mail을 각각의 controller에서 구현하고, 구현한 E-Mail을 보내는 작업만 emailService에서 담당