### PR TITLE
feat : 백엔드의 로그인 API를 사용한 React Query Wrapper 함수 생성

### DIFF
--- a/packages/frontend/src/api/confirmSignIn.test.tsx
+++ b/packages/frontend/src/api/confirmSignIn.test.tsx
@@ -1,0 +1,59 @@
+import { ConfirmSignUpDTO, User } from '@my-task/common';
+import { QueryClient, QueryClientProvider, UseMutationResult } from '@tanstack/react-query';
+import { RenderHookResult, renderHook, waitFor } from '@testing-library/react';
+import { describe, expectTypeOf } from 'vitest';
+import { BE_ORIGIN } from '~/constants';
+import { server } from '~/mock';
+import confirmSignIn from './confirmSignIn';
+
+describe('confirmSignIn', () => {
+  let renderedHook: RenderHookResult<UseMutationResult<any, any, ConfirmSignUpDTO, any>, unknown>;
+
+  const testQueryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+    logger: {
+      log: console.log,
+      warn: console.warn,
+      error: () => {},
+    },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
+  beforeEach(() => location.replace(BE_ORIGIN));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  beforeEach(() => {
+    renderedHook = renderHook(() => confirmSignIn({}), { wrapper });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+  });
+
+  it('should work', async () => {
+    const dto: ConfirmSignUpDTO = { uuid: '993ae2a1-2554-404c-8a86-660b5ee7fedd' };
+    renderedHook.result.current.mutate(dto);
+    await waitFor(() => expect(renderedHook.result.current.isSuccess).toEqual(true));
+
+    const data = renderedHook.result.current.data;
+    expectTypeOf(data).toMatchTypeOf<User>();
+    expect(data.email).toEqual('success@example.com');
+  });
+
+  describe('should fail with', () => {
+    it('invalid email', async () => {
+      const dto: ConfirmSignUpDTO = { uuid: '6aa6ee8e-a4f8-49f6-817f-1c9342aae29e' };
+      renderedHook.result.current.mutate(dto);
+      await waitFor(() => expect(renderedHook.result.current.isError).toEqual(true));
+    });
+  });
+});

--- a/packages/frontend/src/api/confirmSignIn.ts
+++ b/packages/frontend/src/api/confirmSignIn.ts
@@ -1,0 +1,12 @@
+import { ConfirmSignUpDTO, User } from '@my-task/common';
+import { useMutation } from '@tanstack/react-query';
+import { MutationOptions } from '~/types';
+import _fetch from './core';
+
+const confirmSignIn = (options: MutationOptions<User, ConfirmSignUpDTO>) =>
+  useMutation({
+    mutationFn: (body) => _fetch('/auth/signin/ack', { method: 'POST', body }),
+    ...options,
+  });
+
+export default confirmSignIn;

--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -1,4 +1,6 @@
+import confirmSignIn from './confirmSignIn';
 import confirmSignUpUser from './confirmSignUpUser';
 import getConnectionTest from './getConnectionTest';
+import requestSignIn from './requestSignIn';
 import requestSignUpUser from './requestSignUpUser';
-export { getConnectionTest, requestSignUpUser, confirmSignUpUser };
+export { getConnectionTest, requestSignUpUser, requestSignIn, confirmSignUpUser, confirmSignIn };

--- a/packages/frontend/src/api/requestSignIn.test.tsx
+++ b/packages/frontend/src/api/requestSignIn.test.tsx
@@ -1,0 +1,59 @@
+import { RequestSignUpDTO, User } from '@my-task/common';
+import { QueryClient, QueryClientProvider, UseMutationResult } from '@tanstack/react-query';
+import { RenderHookResult, renderHook, waitFor } from '@testing-library/react';
+import { describe, expectTypeOf } from 'vitest';
+import requestSignIn from '~/api/requestSignIn';
+import { BE_ORIGIN } from '~/constants';
+import { server } from '~/mock';
+
+describe('requestSignIn', () => {
+  let renderedHook: RenderHookResult<UseMutationResult<any, any, RequestSignUpDTO, any>, unknown>;
+
+  const testQueryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+    logger: {
+      log: console.log,
+      warn: console.warn,
+      error: () => {},
+    },
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
+  beforeEach(() => location.replace(BE_ORIGIN));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  beforeEach(() => {
+    renderedHook = renderHook(() => requestSignIn({}), { wrapper });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+  });
+
+  it('should work', async () => {
+    const dto: RequestSignUpDTO = { email: 'test@email.com' };
+    renderedHook.result.current.mutate(dto);
+    await waitFor(() => expect(renderedHook.result.current.isSuccess).toEqual(true));
+
+    const data = renderedHook.result.current.data;
+    expectTypeOf(data).toMatchTypeOf<User>();
+    expect(data.email).toEqual(dto.email);
+  });
+
+  describe('should fail with', () => {
+    it('invalid email', async () => {
+      renderedHook.result.current.mutate({ email: 'invalid@email' });
+      await waitFor(() => expect(renderedHook.result.current.isError).toEqual(true));
+    });
+  });
+});

--- a/packages/frontend/src/api/requestSignIn.ts
+++ b/packages/frontend/src/api/requestSignIn.ts
@@ -1,0 +1,12 @@
+import { RequestSignInDTO } from '@my-task/common';
+import { useMutation } from '@tanstack/react-query';
+import { MutationOptions } from '~/types';
+import _fetch from './core';
+
+const requestSignIn = (options: MutationOptions<RequestSignInDTO, RequestSignInDTO>) =>
+  useMutation({
+    mutationFn: (body) => _fetch('/auth/signin/syn', { method: 'POST', body }),
+    ...options,
+  });
+
+export default requestSignIn;

--- a/packages/frontend/src/mock/handlers.ts
+++ b/packages/frontend/src/mock/handlers.ts
@@ -45,4 +45,36 @@ export const handlers = [
 
     return res(ctx.status(200), ctx.json(success));
   }),
+
+  rest.post(mockDir('/auth/signin/syn'), async (req, res, ctx) => {
+    const body = await req.json();
+
+    ctx.delay();
+
+    const result = requestSignUpDTOSchema.safeParse(body);
+    if (!result.success)
+      return res(ctx.status(400), ctx.json({ errorMessage: 'Wrong DTO: try again!' }));
+    const { data } = result;
+
+    return res(ctx.status(200), ctx.json(data));
+  }),
+
+  rest.post(mockDir('/auth/signin/ack'), async (req, res, ctx) => {
+    const body = await req.json();
+
+    ctx.delay();
+
+    const result = confirmSignUpDTOSchema.safeParse(body);
+    if (!result.success)
+      return res(ctx.status(400), ctx.json({ errorMessage: 'Wrong DTO: try again!' }));
+    const { data } = result;
+
+    if (data.uuid === '6aa6ee8e-a4f8-49f6-817f-1c9342aae29e')
+      return res(ctx.status(400), ctx.json({ errorMessage: 'UUID cannot be found: Wrong DTO!' }));
+
+    const id = Math.floor(Math.random() * 10);
+    const success: User = { id, email: 'success@example.com' };
+
+    return res(ctx.status(200), ctx.json(success));
+  }),
 ];


### PR DESCRIPTION
DESC
----
- 백엔드의 로그인 API를 활용하기 위한 프론트엔드 API 생성
- 프론트엔드 API를 테스트하기 위한 mocking handler 생성