### PR TITLE
feat : 캐시 역할을 할 redis 컨테이너 추가

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,15 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      cache:
+        image: redis:7.0.12
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
@@ -66,6 +75,10 @@ jobs:
           EMAIL_PASS: ${{secrets.EMAIL_PASS}}
           EMAIL_SENDER: ${{secrets.EMAIL_SENDER}}
           EMAIL_TEST_RECEIVER: ${{secrets.EMAIL_TEST_RECEIVER}}
+
+          REDIS_PORT: 6379
+          REDIS_USER: default
+          REDIS_PASS: ''
 
           BE_PORT: ${{ vars.BE_PORT }}
           FE_PORT: ${{ vars.FE_PORT }}

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -20,6 +20,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         "reference": "workspace:packages/backend"\
       },\
       {\
+        "name": "@my-task/cache",\
+        "reference": "workspace:packages/cache"\
+      },\
+      {\
         "name": "@my-task/common",\
         "reference": "workspace:packages/common"\
       },\
@@ -36,6 +40,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
     "ignorePatternData": "(^(?:\\\\.yarn\\\\/sdks(?:\\\\/(?!\\\\.{1,2}(?:\\\\/|$))(?:(?:(?!(?:^|\\\\/)\\\\.{1,2}(?:\\\\/|$)).)*?)|$))$)",\
     "fallbackExclusionList": [\
       ["@my-task/backend", ["workspace:packages/backend"]],\
+      ["@my-task/cache", ["workspace:packages/cache"]],\
       ["@my-task/common", ["workspace:packages/common"]],\
       ["@my-task/database", ["workspace:packages/database"]],\
       ["@my-task/frontend", ["workspace:packages/frontend"]],\
@@ -2131,6 +2136,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["typescript", "patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"],\
             ["uuid", "npm:9.0.0"],\
             ["zod", "npm:3.21.4"]\
+          ],\
+          "linkType": "SOFT"\
+        }]\
+      ]],\
+      ["@my-task/cache", [\
+        ["workspace:packages/cache", {\
+          "packageLocation": "./packages/cache/",\
+          "packageDependencies": [\
+            ["@my-task/cache", "workspace:packages/cache"]\
           ],\
           "linkType": "SOFT"\
         }]\

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "backend": "yarn workspace @my-task/backend",
     "common": "yarn workspace @my-task/common",
     "database": "yarn workspace @my-task/database",
+    "redis": "yarn workspace @my-task/cache",
     "stop": "docker-compose down --rmi all && docker image prune -f",
     "start": "yarn stop && docker-compose up -d",
     "test": "act --secret-file=.env --env-file=.env",

--- a/packages/cache/Dockerfile
+++ b/packages/cache/Dockerfile
@@ -1,0 +1,7 @@
+FROM redis:7.0.12
+
+WORKDIR /etc/redis
+
+COPY . .
+
+CMD [ "redis-server", "/etc/redis/redis.conf" ]

--- a/packages/cache/build.sh
+++ b/packages/cache/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+source "../../.env"
+
+touch users.acl
+echo "user $REDIS_USER on >$REDIS_PASS allkeys allcommands" >> users.acl
+
+touch redis.conf
+echo "bind 0.0.0.0" >> redis.conf
+echo "port $REDIS_PORT" >> redis.conf
+echo "maxmemory 1gb" >> redis.conf
+echo "aclfile /etc/redis/users.acl" >> redis.conf
+
+docker build . -t cache
+
+rm users.acl
+rm redis.conf

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@my-task/cache",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "./build.sh",
+    "start": "yarn build && ./start.sh"
+  }
+}

--- a/packages/cache/start.sh
+++ b/packages/cache/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+source "../../.env"
+
+docker run \
+  --name cache \
+  -p $REDIS_PORT:6379 \
+  --expose $REDIS_PORT \
+  --rm \
+  -d \
+  cache
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,6 +1527,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@my-task/cache@workspace:packages/cache":
+  version: 0.0.0-use.local
+  resolution: "@my-task/cache@workspace:packages/cache"
+  languageName: unknown
+  linkType: soft
+
 "@my-task/common@workspace:^, @my-task/common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@my-task/common@workspace:packages/common"


### PR DESCRIPTION
DESC
----
- 세션 관리 및 캐시 역할을 할 cache 컨테이너 생성

NOTE
----
- yarn에서 `cache` 키워드를 사용하므로 script에는 `redis`로 등록함
- redis 설정 파일을 build 시 생성하므로 start 명령어 실행 시 build도 동시에 실행함
- 백엔드에서 redis 이미지를 사용할 때를 대비해 github action에 추가