### PR TITLE
feat : 로그인 시 redis 사용하도록 설정

### DIFF
--- a/packages/backend/src/mock/modules/signin.module.ts
+++ b/packages/backend/src/mock/modules/signin.module.ts
@@ -5,6 +5,7 @@ import { MockCookieService, MockEmailService, MockSignInService } from '~/mock/s
 import { CookieService } from '~/modules/auth/cookie.service';
 import { SignInController } from '~/modules/auth/signin/signin.controller';
 import { SignInService } from '~/modules/auth/signin/signin.service';
+import { CacheService } from '~/modules/cache/cache.service';
 import { DatabaseService } from '~/modules/database/database.service';
 import { EmailService } from '~/modules/email/email.service';
 
@@ -21,7 +22,7 @@ const mockSignInModule = async ({
   cookieService,
   emailService,
 }: Props) => {
-  const providers: Provider[] = [SignInService];
+  const providers: Provider[] = [SignInService, CacheService];
 
   if (databaseService) providers.push(DatabaseService);
   if (cookieService) providers.push(CookieService);

--- a/packages/backend/src/mock/services/signin.service.ts
+++ b/packages/backend/src/mock/services/signin.service.ts
@@ -7,16 +7,19 @@ const mockSignInService = async () => ({
   emailToUuid: new Map<string, string>(),
   async requestSignIn(dto: RequestSignInDTO) {
     const uuid = uuidv4();
+
     this.uuidToEmail.set(uuid, dto);
     this.emailToUuid.set(dto.email, uuid);
+
     return uuid;
   },
   async confirmSignIn(dto: ConfirmSignInDTO) {
-    if (!this.uuidToEmail.has(dto.uuid))
-      throw new BadRequestException('UUID cannot be found: Wrong DTO!');
-    const data = this.uuidToEmail.get(dto.uuid) as RequestSignUpDTO;
+    const { uuid } = dto;
 
-    return data;
+    if (!this.uuidToEmail.has(uuid))
+      throw new BadRequestException('UUID cannot be found: Wrong DTO!');
+
+    return this.uuidToEmail.get(uuid) as RequestSignUpDTO;
   },
 });
 


### PR DESCRIPTION
DESC
----
- SignInService에서 캐시 역할을 하던 uuidToEmail을 redis 캐시로 대체

TEST
----
- 기존 로그인 로직 실행

NOTE
----
- 회원가입 및 로그인에 만료 기간 설정해야 함
- redis에서 transaction을 구현할 수 있는지 확인