### PR TITLE
feat : token 발급 방식 변경

### DIFF
--- a/packages/backend/src/mock/modules/auth.module.ts
+++ b/packages/backend/src/mock/modules/auth.module.ts
@@ -1,10 +1,11 @@
 import { Test } from '@nestjs/testing';
 import { CookieService } from '~/modules/auth/cookie.service';
 import mockConfigModule from './config.module';
+import mockJwtModule from './jwt.module';
 
 const mockAuthModule = async () =>
   Test.createTestingModule({
-    imports: [await mockConfigModule()],
+    imports: [await mockConfigModule(), await mockJwtModule()],
     providers: [CookieService],
   }).compile();
 

--- a/packages/backend/src/mock/modules/index.ts
+++ b/packages/backend/src/mock/modules/index.ts
@@ -4,6 +4,7 @@ import mockConfigModule from './config.module';
 import mockDatabaseModule from './database.module';
 import mockEmailModule from './email.module';
 import mockGroupModule from './group.module';
+import mockJwtModule from './jwt.module';
 import mockSignInModule from './signin.module';
 import mockSignUpModule from './signup.module';
 
@@ -14,6 +15,7 @@ export {
   mockDatabaseModule,
   mockEmailModule,
   mockGroupModule,
+  mockJwtModule,
   mockSignInModule,
   mockSignUpModule,
 };

--- a/packages/backend/src/mock/modules/jwt.module.ts
+++ b/packages/backend/src/mock/modules/jwt.module.ts
@@ -1,0 +1,10 @@
+import { JwtModule } from '@nestjs/jwt';
+
+const mockJwtModule = async () =>
+  JwtModule.register({
+    global: true,
+    publicKey: 'publicKey',
+    privateKey: 'privateKey',
+  });
+
+export default mockJwtModule;

--- a/packages/backend/src/mock/services/cookie.service.ts
+++ b/packages/backend/src/mock/services/cookie.service.ts
@@ -1,4 +1,4 @@
-import { CookieOptions, Response } from 'express';
+import { CookieOptions } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import {
   ACCESS_TOKEN,
@@ -6,6 +6,7 @@ import {
   REFRESH_TOKEN,
   REFRESH_TOKEN_LIFE_SPAN,
 } from '~/constants';
+import { CookieSettings } from '~/types';
 
 const mockCookieService = () => ({
   getExpirationDate(lifeSpan: number) {
@@ -17,12 +18,21 @@ const mockCookieService = () => ({
       httpOnly: true,
     };
   },
-  setCookie(_: string, res: Response) {
-    const accessToken = uuidv4();
+  setCookie(email: string): CookieSettings {
+    const payload = Buffer.from(JSON.stringify({ email })).toString('base64');
+    const accessToken = `a.${payload}.a`;
     const refreshToken = uuidv4();
 
-    res.cookie(ACCESS_TOKEN, accessToken, this.tokenOption(ACCESS_TOKEN_LIFE_SPAN));
-    res.cookie(REFRESH_TOKEN, refreshToken, this.tokenOption(REFRESH_TOKEN_LIFE_SPAN));
+    return {
+      [ACCESS_TOKEN]: {
+        val: `Bearer ${accessToken}`,
+        options: this.tokenOption(ACCESS_TOKEN_LIFE_SPAN),
+      },
+      [REFRESH_TOKEN]: {
+        val: refreshToken,
+        options: this.tokenOption(REFRESH_TOKEN_LIFE_SPAN),
+      },
+    };
   },
 });
 

--- a/packages/backend/src/modules/auth/signin/signin.controller.spec.ts
+++ b/packages/backend/src/modules/auth/signin/signin.controller.spec.ts
@@ -6,13 +6,11 @@ import {
   MockResponse,
   MockSignInService,
   mockCookieService,
-  mockDatabaseModule,
   mockEmailService,
   mockResponse,
   mockSignInModule,
   mockSignInService,
 } from '~/mock';
-import { DatabaseService } from '~/modules/database/database.service';
 import { SignInController } from './signin.controller';
 
 describe('SignInController', () => {
@@ -22,10 +20,6 @@ describe('SignInController', () => {
   let controller: SignInController;
 
   beforeEach(async () => {
-    const databaseModule = await mockDatabaseModule();
-    const databaseService = databaseModule.get<DatabaseService>(DatabaseService);
-    await databaseService.onModuleInit();
-
     [signInService, emailService, cookieService] = await Promise.all([
       mockSignInService(),
       mockEmailService(),
@@ -34,7 +28,6 @@ describe('SignInController', () => {
     const module = await mockSignInModule({
       signInService,
       emailService,
-      databaseService,
       cookieService,
     });
 

--- a/packages/backend/src/modules/auth/signin/signin.controller.ts
+++ b/packages/backend/src/modules/auth/signin/signin.controller.ts
@@ -49,7 +49,10 @@ export class SignInController {
     const { data } = result;
 
     const signedUser = await this.signInService.confirmSignIn(data);
-    this.cookieService.setCookie(signedUser.email, res);
+
+    const cookieSettings = this.cookieService.setCookie(signedUser.email);
+    for (const [key, { val, options }] of Object.entries(cookieSettings))
+      res.cookie(key, val, options);
 
     return signedUser;
   }

--- a/packages/backend/src/types/cookieSettings.ts
+++ b/packages/backend/src/types/cookieSettings.ts
@@ -1,0 +1,10 @@
+import { CookieOptions } from 'express';
+
+type CookieSettings = {
+  [key: string]: {
+    val: string;
+    options: CookieOptions;
+  };
+};
+
+export default CookieSettings;

--- a/packages/backend/src/types/index.ts
+++ b/packages/backend/src/types/index.ts
@@ -1,2 +1,3 @@
+import CookieSettings from './cookieSettings';
 import Env from './env';
-export { Env };
+export type { CookieSettings, Env };


### PR DESCRIPTION
DESC
----
- access token을 uuid에서 jwt로 변경
- Response에 쿠키를 설정하는 부분을 service에서 controller로 변경

NOTE
----
- refresh token은 추후 redis에 저장한 뒤 request를 통해 갱신시킬 예정