### PR TITLE
feat : refresh token을 이용해 access token을 새로 발급

### DIFF
--- a/packages/backend/jest.config.json
+++ b/packages/backend/jest.config.json
@@ -8,6 +8,7 @@
   "collectCoverageFrom": [
     "!<rootDir>/**/*.module.ts",
     "!<rootDir>/**/index.ts",
+    "!<rootDir>/**/mock/**/*",
     "!<rootDir>/**/migrations/*",
     "!<rootDir>/main.ts"
   ],

--- a/packages/backend/src/mock/modules/auth.module.ts
+++ b/packages/backend/src/mock/modules/auth.module.ts
@@ -1,13 +1,14 @@
 import { Test } from '@nestjs/testing';
+import { AuthService } from '~/modules/auth/auth.service';
 import { CookieService } from '~/modules/auth/cookie.service';
 import { CacheService } from '~/modules/cache/cache.service';
 import mockConfigModule from './config.module';
 import mockJwtModule from './jwt.module';
 
-const mockAuthModule = async () =>
+const mockAuthModule = async ({}) =>
   Test.createTestingModule({
     imports: [await mockConfigModule(), await mockJwtModule()],
-    providers: [CookieService, CacheService],
+    providers: [AuthService, CookieService, CacheService],
   }).compile();
 
 export default mockAuthModule;

--- a/packages/backend/src/modules/auth/auth.service.spec.ts
+++ b/packages/backend/src/modules/auth/auth.service.spec.ts
@@ -1,0 +1,52 @@
+import { v4 as uuidv4 } from 'uuid';
+import { ACCESS_TOKEN, REFRESH_TOKEN } from '~/constants';
+import { mockAuthModule } from '~/mock';
+import { AuthService } from '~/modules/auth/auth.service';
+import { CacheService } from '~/modules/cache/cache.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let cacheService: CacheService;
+
+  beforeEach(async () => {
+    const module = await mockAuthModule({});
+    service = module.get<AuthService>(AuthService);
+    cacheService = module.get<CacheService>(CacheService);
+
+    await cacheService.onModuleInit();
+  });
+
+  afterEach(async () => cacheService.onModuleDestroy());
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('refresh', () => {
+    let uuid: string;
+    let email: string;
+    let RT2Email: ReturnType<CacheService['toHash']>;
+
+    beforeEach(async () => {
+      uuid = uuidv4();
+      email = 'test@email.com';
+
+      RT2Email = cacheService.toHash('RT2Email');
+    });
+
+    it('should work', async () => {
+      await RT2Email.set(uuid, email);
+      const result = await service.refresh(uuid);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty(ACCESS_TOKEN);
+      expect(result).toHaveProperty(REFRESH_TOKEN);
+    });
+
+    describe('should throw error when', () => {
+      it('without refresh token', async () => {
+        await expect(service.refresh(uuid)).rejects.toThrow();
+      });
+    });
+  });
+});

--- a/packages/backend/src/modules/auth/auth.service.ts
+++ b/packages/backend/src/modules/auth/auth.service.ts
@@ -1,4 +1,19 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { CookieService } from '~/modules/auth/cookie.service';
+import { CacheService } from '~/modules/cache/cache.service';
 
 @Injectable()
-export class AuthService {}
+export class AuthService {
+  private readonly RT2Email;
+
+  constructor(private readonly cookieService: CookieService, cacheService: CacheService) {
+    this.RT2Email = cacheService.toHash('RT2Email');
+  }
+
+  async refresh(refreshToken: string) {
+    const email = await this.RT2Email.get(refreshToken);
+    if (!email) throw new UnauthorizedException('Cannot identify Refresh Token!');
+    await this.RT2Email.del(refreshToken);
+    return this.cookieService.setCookie(email);
+  }
+}

--- a/packages/backend/src/modules/auth/cookie.service.spec.ts
+++ b/packages/backend/src/modules/auth/cookie.service.spec.ts
@@ -16,7 +16,7 @@ describe('CookieService', () => {
   let cacheService: CacheService;
 
   beforeEach(async () => {
-    const module = await mockAuthModule();
+    const module = await mockAuthModule({});
     service = module.get<CookieService>(CookieService);
     cacheService = module.get<CacheService>(CacheService);
 


### PR DESCRIPTION
DESC
----
- token 재발급 요청 시 refresh token을 이용해 email을 가져온 뒤 token 재발급

NOTE
----
- token 재발급에 CookieService를 사용하고 있으므로 재발급된 token이 valid한지는 테스트하지 않음