### PR TITLE
feat : 회원가입 및 로그인 이메일의 유효기간 설정

### DIFF
--- a/packages/backend/src/constants/cache/index.ts
+++ b/packages/backend/src/constants/cache/index.ts
@@ -1,0 +1,1 @@
+export * from './lifeSpan';

--- a/packages/backend/src/constants/cache/lifeSpan.ts
+++ b/packages/backend/src/constants/cache/lifeSpan.ts
@@ -1,0 +1,4 @@
+import { MINUTE } from '@my-task/common';
+const SIGN_IN_LIFE_SPAN = 10 * MINUTE;
+const SIGN_UP_LIFE_SPAN = 10 * MINUTE;
+export { SIGN_IN_LIFE_SPAN, SIGN_UP_LIFE_SPAN };

--- a/packages/backend/src/constants/index.ts
+++ b/packages/backend/src/constants/index.ts
@@ -1,3 +1,4 @@
 import envPaths from './envPath';
+export * from './cache';
 export * from './token';
 export { envPaths };

--- a/packages/backend/src/modules/auth/auth.module.ts
+++ b/packages/backend/src/modules/auth/auth.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { CookieService } from '~/modules/auth/cookie.service';
 import { GroupModule } from '~/modules/group/group.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -7,7 +8,7 @@ import { SignUpModule } from './signup/signup.module';
 
 @Module({
   imports: [GroupModule, SignUpModule, SignInModule],
-  providers: [AuthService],
+  providers: [AuthService, CookieService],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/packages/backend/src/modules/auth/signin/signin.service.ts
+++ b/packages/backend/src/modules/auth/signin/signin.service.ts
@@ -1,7 +1,8 @@
-import { ConfirmSignInDTO, RequestSignInDTO, users } from '@my-task/common';
+import { ConfirmSignInDTO, RequestSignInDTO, dateAfter, users } from '@my-task/common';
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { eq, sql } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
+import { SIGN_IN_LIFE_SPAN } from '~/constants';
 import { CacheService } from '~/modules/cache/cache.service';
 import { DatabaseService } from '~/modules/database/database.service';
 
@@ -25,8 +26,9 @@ export class SignInService {
     if (Number(count) === 0) throw new BadRequestException('You need to sign up first!');
 
     const uuid = uuidv4();
+    const signInExpiration = dateAfter(SIGN_IN_LIFE_SPAN);
 
-    await this.uuidToEmail.set(uuid, email);
+    await this.uuidToEmail.set(uuid, email, signInExpiration);
 
     return uuid;
   }


### PR DESCRIPTION
DESC
----
- 회원가입 및 로그인 진행 시 캐시에 유효기간 설정
- 캐시 내의 refresh token에 유효기간 설정
- onModuleDestroy 시 기존의 timeout을 전부 clear