### PR TITLE
feat : cache의 tableName을 enum화하여 저장

### DIFF
--- a/packages/backend/src/constants/cache/index.ts
+++ b/packages/backend/src/constants/cache/index.ts
@@ -1,1 +1,3 @@
+import CACHE_TABLE_NAME from './tableName';
 export * from './lifeSpan';
+export { CACHE_TABLE_NAME };

--- a/packages/backend/src/constants/cache/tableName.ts
+++ b/packages/backend/src/constants/cache/tableName.ts
@@ -1,0 +1,9 @@
+const RT2Email = 'RT2Email';
+const pendingEmail = 'pendingEmail';
+const signUpTable = 'signUpTable';
+const signInTable = 'signInTable';
+
+const CACHE_TABLE_NAME = { pendingEmail, RT2Email, signUpTable, signInTable };
+Object.freeze(CACHE_TABLE_NAME);
+
+export default CACHE_TABLE_NAME;

--- a/packages/backend/src/modules/auth/auth.service.ts
+++ b/packages/backend/src/modules/auth/auth.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { CACHE_TABLE_NAME } from '~/constants';
 import { CookieService } from '~/modules/auth/cookie.service';
 import { CacheService } from '~/modules/cache/cache.service';
 
@@ -7,7 +8,7 @@ export class AuthService {
   private readonly RT2Email;
 
   constructor(private readonly cookieService: CookieService, cacheService: CacheService) {
-    this.RT2Email = cacheService.toHash('RT2Email');
+    this.RT2Email = cacheService.toHash(CACHE_TABLE_NAME.RT2Email);
   }
 
   async refresh(refreshToken: string) {

--- a/packages/backend/src/modules/auth/cookie.service.ts
+++ b/packages/backend/src/modules/auth/cookie.service.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   ACCESS_TOKEN,
   ACCESS_TOKEN_LIFE_SPAN,
+  CACHE_TABLE_NAME,
   REFRESH_TOKEN,
   REFRESH_TOKEN_LIFE_SPAN,
 } from '~/constants';
@@ -17,7 +18,7 @@ export class CookieService {
   private readonly RT2Email;
 
   constructor(private readonly jwtService: JwtService, cacheService: CacheService) {
-    this.RT2Email = cacheService.toHash('RT2Email');
+    this.RT2Email = cacheService.toHash(CACHE_TABLE_NAME.RT2Email);
   }
 
   private getExpirationDate(lifeSpan: number) {

--- a/packages/backend/src/modules/auth/signin/signin.service.ts
+++ b/packages/backend/src/modules/auth/signin/signin.service.ts
@@ -2,7 +2,7 @@ import { ConfirmSignInDTO, RequestSignInDTO, dateAfter, users } from '@my-task/c
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { eq, sql } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
-import { SIGN_IN_LIFE_SPAN } from '~/constants';
+import { CACHE_TABLE_NAME, SIGN_IN_LIFE_SPAN } from '~/constants';
 import { CacheService } from '~/modules/cache/cache.service';
 import { DatabaseService } from '~/modules/database/database.service';
 
@@ -13,7 +13,7 @@ export class SignInService {
 
   constructor(cacheService: CacheService, databaseService: DatabaseService) {
     this.db = databaseService.db;
-    this.uuidToEmail = cacheService.toHash('uuidToEmail');
+    this.uuidToEmail = cacheService.toHash(CACHE_TABLE_NAME.signInTable);
   }
 
   async requestSignIn(dto: RequestSignInDTO) {

--- a/packages/backend/src/modules/auth/signup/signup.service.ts
+++ b/packages/backend/src/modules/auth/signup/signup.service.ts
@@ -2,7 +2,7 @@ import { ConfirmSignUpDTO, RequestSignUpDTO, dateAfter, users } from '@my-task/c
 import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { eq, sql } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
-import { SIGN_UP_LIFE_SPAN } from '~/constants';
+import { CACHE_TABLE_NAME, SIGN_UP_LIFE_SPAN } from '~/constants';
 import { CacheService } from '~/modules/cache/cache.service';
 import { DatabaseService } from '~/modules/database/database.service';
 
@@ -14,8 +14,8 @@ export class SignUpService {
 
   constructor(cacheService: CacheService, databaseService: DatabaseService) {
     this.db = databaseService.db;
-    this.pendingEmail = cacheService.toSet('PendingEmail');
-    this.uuidToEmail = cacheService.toHash('uuidToEmail');
+    this.pendingEmail = cacheService.toSet(CACHE_TABLE_NAME.pendingEmail);
+    this.uuidToEmail = cacheService.toHash(CACHE_TABLE_NAME.signUpTable);
   }
 
   async requestSignUp(dto: RequestSignUpDTO) {


### PR DESCRIPTION
DESC
----
- cache의 tableName을 enum화하여 저장
  - signup과 signin에서 사용하는 uuidToEmail의 테이블 이름을 다르게 설정