### PR TITLE
feat : frontend에서 일정 기간마다 token refresh 요청

### DIFF
--- a/packages/common/src/dto/auth/index.ts
+++ b/packages/common/src/dto/auth/index.ts
@@ -1,2 +1,3 @@
+export * from './refreshed.dto';
 export * from './signin';
 export * from './signup';

--- a/packages/common/src/dto/auth/refreshed.dto.ts
+++ b/packages/common/src/dto/auth/refreshed.dto.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+const refreshedDTOSchema = z.object({
+  refreshed: z.boolean(),
+});
+
+type RefreshedDTO = ReturnType<typeof refreshedDTOSchema.parse>;
+
+export { refreshedDTOSchema };
+export type { RefreshedDTO };

--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -1,6 +1,15 @@
 import confirmSignIn from './confirmSignIn';
-import requestSignIn from './requestSignIn';
 import confirmSignUp from './confirmSignUp';
 import getConnectionTest from './getConnectionTest';
+import refreshToken from './refreshToken';
+import requestSignIn from './requestSignIn';
 import requestSignUp from './requestSignUp';
-export { getConnectionTest, requestSignUp, confirmSignUp, requestSignIn, confirmSignIn };
+
+export {
+  confirmSignIn,
+  confirmSignUp,
+  getConnectionTest,
+  refreshToken,
+  requestSignIn,
+  requestSignUp,
+};

--- a/packages/frontend/src/api/refreshToken.ts
+++ b/packages/frontend/src/api/refreshToken.ts
@@ -1,0 +1,12 @@
+import { RefreshedDTO } from '@my-task/common';
+import { useQuery } from '@tanstack/react-query';
+import { QueryOptions } from '~/types';
+import _fetch from './core';
+
+const refreshToken = (option: QueryOptions<RefreshedDTO>) =>
+  useQuery({
+    queryFn: () => _fetch('/auth', { method: 'GET' }),
+    ...option,
+  });
+
+export default refreshToken;

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -1,8 +1,30 @@
+import { MINUTE } from '@my-task/common';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
+import { refreshToken } from '~/api';
 import '~/index.css';
 import router from '~/routes';
+
+const App = () => {
+  const [refresh, setRefresh] = useState(true);
+
+  if (refresh) {
+    const result = refreshToken({
+      refetchInterval: 10 * MINUTE,
+      refetchIntervalInBackground: true,
+    });
+
+    if (result.error) setRefresh(false);
+  }
+
+  return (
+    <QueryClientProvider client={new QueryClient()}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
+};
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   // <React.StrictMode>
@@ -10,7 +32,5 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   //     <RouterProvider router={router} />
   //   </QueryClientProvider>
   // </React.StrictMode>,
-  <QueryClientProvider client={new QueryClient()}>
-    <RouterProvider router={router} />
-  </QueryClientProvider>,
+  App(),
 );

--- a/packages/frontend/src/types/QueryOptions.ts
+++ b/packages/frontend/src/types/QueryOptions.ts
@@ -1,0 +1,12 @@
+import { JsonObject } from '@my-task/common';
+import { useQuery } from '@tanstack/react-query';
+
+type BackendError = {
+  errorMessage: string;
+  status: number;
+};
+
+type QueryOptions<Output extends JsonObject> = Parameters<
+  typeof useQuery<unknown, BackendError, Output>
+>[2];
+export default QueryOptions;

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -1,2 +1,3 @@
 import MutationOptions from './MutationOptions';
-export type { MutationOptions };
+import QueryOptions from './QueryOptions';
+export type { MutationOptions, QueryOptions };


### PR DESCRIPTION
DESC
----
- react query의 `refetchInterval`을 이용해 일정 시간마다 token refresh 요청을 전송

NOTE
----
- token의 설정 여부에 따라 테스트하는 방법을 알지 못함
- 로그인 혹은 로그아웃 등에 영향을 받지 않음