### PR TITLE
Feature/auth-refact-02-endpoint

### DIFF
--- a/packages/backend/src/constants/cache/tableName.ts
+++ b/packages/backend/src/constants/cache/tableName.ts
@@ -2,8 +2,9 @@ const RT2Email = 'RT2Email';
 const pendingEmail = 'pendingEmail';
 const signUpTable = 'signUpTable';
 const signInTable = 'signInTable';
+const uuidToEmail = 'uuidToEmail';
 
-const CACHE_TABLE_NAME = { pendingEmail, RT2Email, signUpTable, signInTable };
+const CACHE_TABLE_NAME = { pendingEmail, RT2Email, signUpTable, signInTable, uuidToEmail };
 Object.freeze(CACHE_TABLE_NAME);
 
 export default CACHE_TABLE_NAME;

--- a/packages/backend/src/mock/modules/auth.module.ts
+++ b/packages/backend/src/mock/modules/auth.module.ts
@@ -1,28 +1,59 @@
+import { Provider } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { MockAuthService } from '~/mock/services';
+import {
+  MockAuthService,
+  MockCookieService,
+  MockEmailService,
+  MockGroupService,
+} from '~/mock/services';
 import { AuthController } from '~/modules/auth/auth.controller';
 import { AuthService } from '~/modules/auth/auth.service';
 import { CookieService } from '~/modules/auth/cookie.service';
 import { JwtStrategy } from '~/modules/auth/strategy';
 import { CacheService } from '~/modules/cache/cache.service';
+import { DatabaseService } from '~/modules/database/database.service';
+import { EmailService } from '~/modules/email/email.service';
+import { GroupService } from '~/modules/group/group.service';
 import mockConfigModule from './config.module';
 import mockJwtModule from './jwt.module';
 
 type Props = {
   authService?: MockAuthService;
+  cookieService?: MockCookieService;
+  databaseService?: DatabaseService;
+  emailService?: MockEmailService;
+  groupService?: MockGroupService;
 };
 
-const mockAuthModule = async ({ authService }: Props) => {
-  const useController = !!authService;
+const mockAuthModule = async ({
+  authService,
+  cookieService,
+  databaseService,
+  emailService,
+  groupService,
+}: Props) => {
+  const providers: Provider[] = [CookieService, CacheService, JwtStrategy];
+
+  if (authService || databaseService) providers.push(AuthService);
+  if (cookieService) providers.push(CookieService);
+  if (databaseService) providers.push(DatabaseService);
+  if (emailService) providers.push(EmailService);
+  if (groupService) providers.push(GroupService);
+
+  const useController = !!authService && !!cookieService;
   const controllers = useController ? [AuthController] : [];
 
   const moduleFactory = Test.createTestingModule({
     imports: [await mockConfigModule(), await mockJwtModule()],
-    providers: [AuthService, CookieService, CacheService, JwtStrategy],
+    providers,
     controllers,
   });
 
   if (authService) moduleFactory.overrideProvider(AuthService).useValue(authService);
+  if (cookieService) moduleFactory.overrideProvider(CookieService).useValue(cookieService);
+  if (databaseService) moduleFactory.overrideProvider(DatabaseService).useValue(databaseService);
+  if (emailService) moduleFactory.overrideProvider(EmailService).useValue(emailService);
+  if (groupService) moduleFactory.overrideProvider(GroupService).useValue(groupService);
 
   return moduleFactory.compile();
 };

--- a/packages/backend/src/mock/services/auth.service.ts
+++ b/packages/backend/src/mock/services/auth.service.ts
@@ -1,7 +1,30 @@
+import { ConfirmAuthDTO, RequestAuthDTO } from '@my-task/common';
+import { BadRequestException } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
 import { mockCookieService } from '~/mock/services/cookie.service';
 
 const mockAuthService = async () => ({
   cookieService: mockCookieService(),
+  uuidToEmail: new Map<string, string>(),
+  emailToUuid: new Map<string, string>(),
+
+  async request(dto: RequestAuthDTO) {
+    const { email } = dto;
+    const uuid = uuidv4();
+
+    this.uuidToEmail.set(uuid, email);
+    this.emailToUuid.set(email, uuid);
+
+    return uuid;
+  },
+  async confirm(dto: ConfirmAuthDTO) {
+    const { uuid } = dto;
+    const email = this.uuidToEmail.get(uuid);
+
+    if (!email) throw new BadRequestException('UUID cannot be found: Wrong DTO!');
+
+    return { email };
+  },
 
   refresh(_: string) {
     const email = 'test@email.com';

--- a/packages/backend/src/modules/auth/auth.controller.ts
+++ b/packages/backend/src/modules/auth/auth.controller.ts
@@ -1,20 +1,78 @@
+import { confirmAuthDTOSchema, requestAuthDTOSchema } from '@my-task/common';
 import {
+  BadRequestException,
+  Body,
   Controller,
   Delete,
   Get,
+  Post,
   Req,
   Res,
   UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Request, Response } from 'express';
 import { ACCESS_TOKEN, REFRESH_TOKEN } from '~/constants';
 import { JwtGuard } from '~/guard';
 import { AuthService } from '~/modules/auth/auth.service';
+import { CookieService } from '~/modules/auth/cookie.service';
+import { EmailService } from '~/modules/email/email.service';
+import { CookieSettings, Env } from '~/types';
 
 @Controller()
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  private readonly FE_ORIGIN: string;
+
+  constructor(
+    private readonly authService: AuthService,
+    private readonly cookieService: CookieService,
+    private readonly emailService: EmailService,
+    configService: ConfigService<Env>,
+  ) {
+    const { HOST, FE_PORT } = configService.getOrThrow<Env['NETWORK']>('NETWORK');
+    this.FE_ORIGIN = `http://${HOST}:${FE_PORT}`;
+  }
+
+  private sendEmail(receiver: string, uuid: string) {
+    return this.emailService.sendEmail(
+      receiver,
+      '[MyTask] Please verify your E-Mail!',
+      `Click <a href="${this.FE_ORIGIN}/signin/${uuid}">HERE</a> to verify your E-Mail!`,
+    );
+  }
+
+  private setAuthCookie(res: Response, cookieSettings: CookieSettings) {
+    for (const [key, { val, options }] of Object.entries(cookieSettings))
+      res.cookie(key, val, options);
+  }
+
+  @Post('request')
+  async request(@Body() body: any) {
+    const result = requestAuthDTOSchema.safeParse(body);
+    if (!result.success) throw new BadRequestException('Wrong DTO: try again!');
+    const { data } = result;
+
+    const uuid = await this.authService.request(data);
+    // E-Mail 송신은 동기적으로 진행할 필요 없음
+    this.sendEmail(data.email, uuid);
+
+    return data;
+  }
+
+  @Post('confirm')
+  async confirm(@Body() body: any, @Res({ passthrough: true }) res: Response) {
+    const result = confirmAuthDTOSchema.safeParse(body);
+    if (!result.success) throw new BadRequestException('Wrong DTO: try again!');
+    const { data } = result;
+
+    const authInfo = await this.authService.confirm(data);
+
+    const cookieSettings = await this.cookieService.setCookie(authInfo.email);
+    this.setAuthCookie(res, cookieSettings);
+
+    return authInfo;
+  }
 
   @Get()
   async refresh(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
@@ -22,9 +80,8 @@ export class AuthController {
     if (!refreshToken) throw new UnauthorizedException('Logout by timeout!');
 
     const cookieSettings = await this.authService.refresh(refreshToken);
+    this.setAuthCookie(res, cookieSettings);
 
-    for (const [key, { val, options }] of Object.entries(cookieSettings))
-      res.cookie(key, val, options);
     return { refreshed: true };
   }
 

--- a/packages/backend/src/modules/auth/auth.service.spec.ts
+++ b/packages/backend/src/modules/auth/auth.service.spec.ts
@@ -1,51 +1,80 @@
+import { RequestAuthDTO } from '@my-task/common';
 import { v4 as uuidv4 } from 'uuid';
+import { z } from 'zod';
 import { ACCESS_TOKEN, REFRESH_TOKEN } from '~/constants';
-import { mockAuthModule } from '~/mock';
+import { mockAuthModule, mockDatabaseModule } from '~/mock';
 import { AuthService } from '~/modules/auth/auth.service';
 import { CacheService } from '~/modules/cache/cache.service';
+import { DatabaseService } from '~/modules/database/database.service';
 
 describe('AuthService', () => {
   let service: AuthService;
+  let databaseService: DatabaseService;
   let cacheService: CacheService;
 
-  let RT2Email: ReturnType<CacheService['toHash']>;
-  let uuid: string;
   let email: string;
+  let uuid: string;
+  let userToAdd: RequestAuthDTO;
+
+  let RT2Email: ReturnType<CacheService['toHash']>;
 
   beforeEach(async () => {
-    const module = await mockAuthModule({});
+    const databaseModule = await mockDatabaseModule();
+    databaseService = databaseModule.get<DatabaseService>(DatabaseService);
+    await databaseService.onModuleInit();
+
+    const module = await mockAuthModule({ databaseService });
     service = module.get<AuthService>(AuthService);
     cacheService = module.get<CacheService>(CacheService);
 
-    RT2Email = cacheService.toHash('RT2Email');
-
     await cacheService.onModuleInit();
-  });
-
-  beforeEach(async () => {
-    email = 'test@email.com';
-    uuid = uuidv4();
-
-    await RT2Email.set(uuid, email);
+    RT2Email = cacheService.toHash('RT2Email');
   });
 
   afterEach(async () => cacheService.onModuleDestroy());
+
+  beforeEach(() => {
+    email = 'create@example.email';
+    userToAdd = { email };
+  });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
 
-  describe('removeRefreshToken', () => {
+  describe('request', () => {
+    it('should work (validation will be in controller)', async () => {
+      const result = await service.request(userToAdd);
+      const parsedResult = z.string().uuid().safeParse(result);
+      expect(parsedResult.success).toEqual(true);
+    });
+  });
+
+  describe('confirm (validation will be in controller)', () => {
+    beforeEach(async () => {
+      uuid = await service.request(userToAdd);
+    });
+
     it('should work', async () => {
-      expect(await RT2Email.get(uuid)).toBeDefined();
-      expect(service.removeRefreshToken(uuid)).resolves.not.toThrow();
-      expect(await RT2Email.get(uuid)).toBeNull();
+      let result;
+      expect((result = await service.confirm({ uuid }))).toBeDefined();
+      expect(result.email).toEqual(email);
+    });
+
+    describe('should throw error when', () => {
+      it('non-existing uuid', async () => {
+        uuid = uuidv4();
+        await expect(async () => service.confirm({ uuid })).rejects.toThrow();
+      });
+
+      it('pass same parameter', async () => {
+        await service.confirm({ uuid });
+        await expect(async () => service.confirm({ uuid })).rejects.toThrow();
+      });
     });
   });
 
   describe('refresh', () => {
-    let uuid: string;
-
     beforeEach(async () => {
       uuid = uuidv4();
     });
@@ -62,8 +91,27 @@ describe('AuthService', () => {
 
     describe('should throw error when', () => {
       it('without refresh token', async () => {
-        await expect(service.refresh(uuidv4())).rejects.toThrow();
+        await expect(service.refresh(uuid)).rejects.toThrow();
       });
+    });
+  });
+
+  describe('removeRefreshToken', () => {
+    beforeEach(async () => {
+      uuid = uuidv4();
+    });
+
+    it('should work', async () => {
+      await RT2Email.set(uuid, email);
+
+      expect(await RT2Email.get(uuid)).toBeDefined();
+      await expect(service.removeRefreshToken(uuid)).resolves.not.toThrow();
+      expect(await RT2Email.get(uuid)).toBeNull();
+    });
+
+    it('should not throw when uuid not exists', async () => {
+      expect(await RT2Email.get(uuid)).toBeNull();
+      await expect(service.removeRefreshToken(uuid)).resolves.not.toThrow();
     });
   });
 });

--- a/packages/backend/src/modules/auth/auth.service.ts
+++ b/packages/backend/src/modules/auth/auth.service.ts
@@ -1,14 +1,71 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { CACHE_TABLE_NAME } from '~/constants';
+import { ConfirmAuthDTO, RequestAuthDTO, dateAfter, users } from '@my-task/common';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { eq, sql } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import { CACHE_TABLE_NAME, SIGN_IN_LIFE_SPAN } from '~/constants';
 import { CookieService } from '~/modules/auth/cookie.service';
 import { CacheService } from '~/modules/cache/cache.service';
+import { DatabaseService } from '~/modules/database/database.service';
 
 @Injectable()
 export class AuthService {
+  private readonly db;
+  private readonly uuidToEmail;
   private readonly RT2Email;
 
-  constructor(private readonly cookieService: CookieService, cacheService: CacheService) {
+  constructor(
+    private readonly cookieService: CookieService,
+    cacheService: CacheService,
+    databaseService: DatabaseService,
+  ) {
+    this.db = databaseService.db;
+    this.uuidToEmail = cacheService.toHash(CACHE_TABLE_NAME.uuidToEmail);
     this.RT2Email = cacheService.toHash(CACHE_TABLE_NAME.RT2Email);
+  }
+
+  private async createUserIfNotExist(email: string) {
+    const [{ countAsStr }] = await this.db
+      .select({ countAsStr: sql<string>`count(email)` })
+      .from(users)
+      .where(eq(users.email, email));
+
+    const count = parseInt(countAsStr);
+
+    if (count === 0) {
+      const insertedUsers = await this.db.insert(users).values({ email }).returning();
+      if (insertedUsers.length !== 1)
+        throw new InternalServerErrorException('DB insertion failed!');
+    }
+
+    return count === 0;
+  }
+
+  async request(dto: RequestAuthDTO) {
+    const { email } = dto;
+
+    const uuid = uuidv4();
+    const signInExpiration = dateAfter(SIGN_IN_LIFE_SPAN);
+
+    await this.uuidToEmail.set(uuid, email, signInExpiration);
+
+    return uuid;
+  }
+
+  async confirm(dto: ConfirmAuthDTO) {
+    const { uuid } = dto;
+    const email = await this.uuidToEmail.get(uuid);
+
+    if (!email) throw new BadRequestException('UUID cannot be found: Wrong DTO!');
+
+    await this.uuidToEmail.del(uuid);
+    await this.createUserIfNotExist(email);
+
+    return { email };
   }
 
   async refresh(refreshToken: string) {


### PR DESCRIPTION
DESC
----
- auth request와 confirm의 위치를 변경
- auth request 시 사용자가 DB에 존재하는지 확인하지 않음
- auth confirm 시 사용자가 DB에 존재하지 않는다면 사용자를 생성

NOTE
----
- 같은 dto로 여러 번 요청을 보낼 경우 예외처리가 필요함
  - 같은 email로 request를 여러 번 보낼 경우 이전의 요청을 무효화할 필요가 있음
  - 같은 uuid로 request를 여러 번 보낼 경우 첫 번째 혹은 마지막 요청만 받아들어야 함
- frontend에서 새로 만든 endpoint로 요청을 보내도록 수정해야 함