### PR TITLE
feat : cookie의 lifeSpan이 의도한 대로 설정되도록 변경

### DIFF
--- a/packages/backend/src/modules/auth/cookie.service.spec.ts
+++ b/packages/backend/src/modules/auth/cookie.service.spec.ts
@@ -37,8 +37,6 @@ describe('CookieService', () => {
     });
 
     describe('should create token', () => {
-      let before: number;
-      let after: number;
       let cookieSettings: CookieSettings;
 
       const getJwtPayload = (jwt: string) => {
@@ -48,9 +46,7 @@ describe('CookieService', () => {
       };
 
       beforeEach(async () => {
-        before = new Date().getTime();
         cookieSettings = await service.setCookie(email);
-        after = new Date().getTime();
       });
 
       it('access token', () => {
@@ -67,10 +63,8 @@ describe('CookieService', () => {
 
         expect(httpOnly).toEqual(true);
 
-        expect(after - before).toBeLessThan(1000);
         expect(maxAge).toBeDefined();
-        expect((maxAge as number) - before).toBeGreaterThanOrEqual(ACCESS_TOKEN_LIFE_SPAN);
-        expect((maxAge as number) - after).toBeLessThanOrEqual(ACCESS_TOKEN_LIFE_SPAN);
+        expect(maxAge as number).toEqual(ACCESS_TOKEN_LIFE_SPAN);
       });
 
       it('refresh token', () => {
@@ -85,10 +79,8 @@ describe('CookieService', () => {
 
         expect(httpOnly).toEqual(true);
 
-        expect(after - before).toBeLessThan(1000);
         expect(maxAge).toBeDefined();
-        expect((maxAge as number) - before).toBeGreaterThanOrEqual(REFRESH_TOKEN_LIFE_SPAN);
-        expect((maxAge as number) - after).toBeLessThanOrEqual(REFRESH_TOKEN_LIFE_SPAN);
+        expect(maxAge as number).toEqual(REFRESH_TOKEN_LIFE_SPAN);
       });
     });
   });

--- a/packages/backend/src/modules/auth/cookie.service.ts
+++ b/packages/backend/src/modules/auth/cookie.service.ts
@@ -21,27 +21,24 @@ export class CookieService {
     this.RT2Email = cacheService.toHash(CACHE_TABLE_NAME.RT2Email);
   }
 
-  private getExpirationDate(lifeSpan: number) {
-    return dateAfter(lifeSpan);
-  }
-
   private tokenOption(lifeSpan: number): CookieOptions & { maxAge: number } {
     return {
-      maxAge: this.getExpirationDate(lifeSpan).getTime(),
+      maxAge: lifeSpan,
       httpOnly: true,
     };
   }
 
   async setCookie(email: string): Promise<CookieSettings> {
     const payload = { email };
-
     const accessToken = this.jwtService.sign(payload, {
       expiresIn: ACCESS_TOKEN_LIFE_SPAN / SECOND,
     });
+
     const refreshToken = uuidv4();
     const refreshTokenOption = this.tokenOption(REFRESH_TOKEN_LIFE_SPAN);
+    const refreshTokenExpireDate = dateAfter(refreshTokenOption.maxAge);
 
-    await this.RT2Email.set(refreshToken, email, new Date(refreshTokenOption.maxAge));
+    await this.RT2Email.set(refreshToken, email, refreshTokenExpireDate);
 
     return {
       [ACCESS_TOKEN]: {


### PR DESCRIPTION
DESC
----
- cookie의 lifeSpan 설정을 Date를 경유한 값에서 바로 millisecond로 변경
- refresh token의 cache와 cookie에서 lifeSpan이 최대한 같도록 수정