### PR TITLE
feat : 통합된 auth endpoint에 대한 react query API 생성

### DIFF
--- a/packages/frontend/src/api/auth/confirm.test.tsx
+++ b/packages/frontend/src/api/auth/confirm.test.tsx
@@ -1,0 +1,59 @@
+import { ConfirmAuthDTO } from '@my-task/common';
+import { QueryClient, QueryClientProvider, UseMutationResult } from '@tanstack/react-query';
+import { RenderHookResult, renderHook, waitFor } from '@testing-library/react';
+import { describe } from 'vitest';
+import { BE_ORIGIN } from '~/constants';
+import { server } from '~/mock';
+import confirmAuth from './confirm';
+
+describe('confirmAuth', () => {
+  let renderedHook: RenderHookResult<UseMutationResult<any, any, ConfirmAuthDTO, any>, unknown>;
+
+  const testQueryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+    logger: {
+      log: console.log,
+      warn: console.warn,
+      error: () => {},
+    },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
+  beforeEach(() => location.replace(BE_ORIGIN));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  beforeEach(() => {
+    renderedHook = renderHook(() => confirmAuth({}), { wrapper });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+  });
+
+  it('should work', async () => {
+    const dto: ConfirmAuthDTO = { uuid: '993ae2a1-2554-404c-8a86-660b5ee7fedd' };
+    renderedHook.result.current.mutate(dto);
+    await waitFor(() => expect(renderedHook.result.current.isSuccess).toEqual(true));
+
+    const data = renderedHook.result.current.data;
+    expect(data).toHaveProperty('email');
+    expect(data.email).toEqual('success@example.com');
+  });
+
+  describe('should fail with', () => {
+    it('invalid email', async () => {
+      const dto: ConfirmAuthDTO = { uuid: '6aa6ee8e-a4f8-49f6-817f-1c9342aae29e' };
+      renderedHook.result.current.mutate(dto);
+      await waitFor(() => expect(renderedHook.result.current.isError).toEqual(true));
+    });
+  });
+});

--- a/packages/frontend/src/api/auth/confirm.ts
+++ b/packages/frontend/src/api/auth/confirm.ts
@@ -1,0 +1,12 @@
+import { ConfirmAuthDTO } from '@my-task/common';
+import { useMutation } from '@tanstack/react-query';
+import { MutationOptions } from '~/types';
+import _fetch from '../core';
+
+const confirmAuth = (options: MutationOptions<{ email: string }, ConfirmAuthDTO>) =>
+  useMutation({
+    mutationFn: (body) => _fetch('/auth/confirm', { method: 'POST', body }),
+    ...options,
+  });
+
+export default confirmAuth;

--- a/packages/frontend/src/api/auth/index.ts
+++ b/packages/frontend/src/api/auth/index.ts
@@ -1,0 +1,3 @@
+import confirmAuth from './confirm';
+import requestAuth from './request';
+export { confirmAuth, requestAuth };

--- a/packages/frontend/src/api/auth/request.test.tsx
+++ b/packages/frontend/src/api/auth/request.test.tsx
@@ -1,0 +1,58 @@
+import { RequestAuthDTO, User } from '@my-task/common';
+import { QueryClient, QueryClientProvider, UseMutationResult } from '@tanstack/react-query';
+import { RenderHookResult, renderHook, waitFor } from '@testing-library/react';
+import { describe, expectTypeOf } from 'vitest';
+import { BE_ORIGIN } from '~/constants';
+import { server } from '~/mock';
+import requestAuth from './request';
+
+describe('requestAuth', () => {
+  let renderedHook: RenderHookResult<UseMutationResult<any, any, RequestAuthDTO, any>, unknown>;
+
+  const testQueryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+    logger: {
+      log: console.log,
+      warn: console.warn,
+      error: () => {},
+    },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
+  beforeEach(() => location.replace(BE_ORIGIN));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  beforeEach(() => {
+    renderedHook = renderHook(() => requestAuth({}), { wrapper });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+  });
+
+  it('should work', async () => {
+    const dto: RequestAuthDTO = { email: 'test@email.com' };
+    renderedHook.result.current.mutate(dto);
+    await waitFor(() => expect(renderedHook.result.current.isSuccess).toEqual(true));
+
+    const data = renderedHook.result.current.data;
+    expectTypeOf(data).toMatchTypeOf<User>();
+    expect(data.email).toEqual(dto.email);
+  });
+
+  describe('should fail with', () => {
+    it('invalid email', async () => {
+      renderedHook.result.current.mutate({ email: 'invalid@email' });
+      await waitFor(() => expect(renderedHook.result.current.isError).toEqual(true));
+    });
+  });
+});

--- a/packages/frontend/src/api/auth/request.ts
+++ b/packages/frontend/src/api/auth/request.ts
@@ -1,0 +1,12 @@
+import { RequestAuthDTO } from '@my-task/common';
+import { useMutation } from '@tanstack/react-query';
+import { MutationOptions } from '~/types';
+import _fetch from '../core';
+
+const requestAuth = (options: MutationOptions<RequestAuthDTO, RequestAuthDTO>) =>
+  useMutation({
+    mutationFn: (body) => _fetch('/auth/request', { method: 'POST', body }),
+    ...options,
+  });
+
+export default requestAuth;

--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -5,6 +5,7 @@ import refreshToken from './refreshToken';
 import requestSignIn from './requestSignIn';
 import requestSignUp from './requestSignUp';
 
+export * from './auth';
 export {
   confirmSignIn,
   confirmSignUp,

--- a/packages/frontend/src/mock/handlers.ts
+++ b/packages/frontend/src/mock/handlers.ts
@@ -1,4 +1,10 @@
-import { User, confirmSignUpDTOSchema, requestSignUpDTOSchema } from '@my-task/common';
+import {
+  User,
+  confirmAuthDTOSchema,
+  confirmSignUpDTOSchema,
+  requestAuthDTOSchema,
+  requestSignUpDTOSchema,
+} from '@my-task/common';
 import { rest } from 'msw';
 import { BE_ORIGIN } from '~/constants';
 
@@ -13,6 +19,8 @@ export const handlers = [
   rest.get(`${BE_ORIGIN}/error`, (_, res, ctx) =>
     res(ctx.status(400), ctx.json({ errorMessage: 'Error thrown for unknown reason.' })),
   ),
+
+  // -----------------------------------------
 
   rest.post(mockDir('/auth/signup/syn'), async (req, res, ctx) => {
     const body = await req.json();
@@ -74,6 +82,39 @@ export const handlers = [
 
     const id = Math.floor(Math.random() * 10);
     const success: User = { id, email: 'success@example.com' };
+
+    return res(ctx.status(200), ctx.json(success));
+  }),
+
+  // -----------------------------------------
+
+  rest.post(mockDir('/auth/request'), async (req, res, ctx) => {
+    const body = await req.json();
+
+    ctx.delay();
+
+    const result = requestAuthDTOSchema.safeParse(body);
+    if (!result.success)
+      return res(ctx.status(400), ctx.json({ errorMessage: 'Wrong DTO: try again!' }));
+    const { data } = result;
+
+    return res(ctx.status(200), ctx.json(data));
+  }),
+
+  rest.post(mockDir('/auth/confirm'), async (req, res, ctx) => {
+    const body = await req.json();
+
+    ctx.delay();
+
+    const result = confirmAuthDTOSchema.safeParse(body);
+    if (!result.success)
+      return res(ctx.status(400), ctx.json({ errorMessage: 'Wrong DTO: try again!' }));
+    const { data } = result;
+
+    if (data.uuid === '6aa6ee8e-a4f8-49f6-817f-1c9342aae29e')
+      return res(ctx.status(400), ctx.json({ errorMessage: 'UUID cannot be found: Wrong DTO!' }));
+
+    const success = { email: 'success@example.com' };
 
     return res(ctx.status(200), ctx.json(success));
   }),

--- a/packages/frontend/src/types/QueryOptions.ts
+++ b/packages/frontend/src/types/QueryOptions.ts
@@ -7,6 +7,6 @@ type BackendError = {
 };
 
 type QueryOptions<Output extends JsonObject> = Parameters<
-  typeof useQuery<unknown, BackendError, Output>
+  typeof useQuery<unknown, BackendError, Output, string[]>
 >[2];
 export default QueryOptions;


### PR DESCRIPTION
DESC
----
- 통합된 auth endpoint에 대한 react query API 생성

NOTE
----
- QueryOptions에서 queryKey 타입을 `string[]`으로 정의
- 기존 API 및 mock endpoint는 API 대체 이후 제거