### PR TITLE
feat : Frontend와 Backend의 통신에 cookie를 사용할 수 있도록 설정

### DIFF
--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -9,7 +9,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const { HOST, BE_PORT, FE_PORT } = getConfig(app);
 
-  const corsOptions = { origin: `http://${HOST}:${FE_PORT}` };
+  const corsOptions = { origin: `http://${HOST}:${FE_PORT}`, credentials: true };
   app.enableCors(corsOptions);
   app.use(cookieParser());
   await app.listen(BE_PORT);

--- a/packages/frontend/src/api/core/index.ts
+++ b/packages/frontend/src/api/core/index.ts
@@ -1,7 +1,7 @@
 import { JsonObject, mergeObjects } from '@my-task/common';
 import { BE_ORIGIN, DEFAULT_FETCH_OPTIONS } from '~/constants';
 
-type RequestOption<BodyType extends JsonObject> = JsonObject & {
+type RequestOption<BodyType extends JsonObject> = Partial<Pick<JsonObject, keyof RequestInit>> & {
   body?: BodyType;
 };
 

--- a/packages/frontend/src/constants/defaultFetchOptions.ts
+++ b/packages/frontend/src/constants/defaultFetchOptions.ts
@@ -3,6 +3,7 @@ import { JsonObject } from '@my-task/common';
 const DEFAULT_FETCH_OPTIONS: Partial<Pick<JsonObject, keyof RequestInit>> = {
   method: 'GET',
   headers: { 'Content-Type': 'application/json' },
+  credentials: 'include',
 };
 
 export default DEFAULT_FETCH_OPTIONS;


### PR DESCRIPTION
DESC
----
- Backend의 cors option에 credentials를 주어 cookie를 사용할 수 있도록 설정
- Frontend의 default fetch option에 credentials를 주어 cookie를 보낼 수 있도록 설정