### PR TITLE
feat : 로그아웃 frontend API 생성

### DIFF
--- a/packages/frontend/src/api/auth/index.ts
+++ b/packages/frontend/src/api/auth/index.ts
@@ -1,4 +1,5 @@
 import confirmAuth from './confirm';
 import refreshAuth from './refresh';
+import removeAuth from './remove';
 import requestAuth from './request';
-export { confirmAuth, requestAuth, refreshAuth };
+export { confirmAuth, requestAuth, refreshAuth, removeAuth };

--- a/packages/frontend/src/api/auth/remove.ts
+++ b/packages/frontend/src/api/auth/remove.ts
@@ -1,0 +1,13 @@
+import { RefreshedDTO } from '@my-task/common';
+import { useMutation } from '@tanstack/react-query';
+import { MutationOptions } from '~/types';
+import _fetch from '../core';
+
+const removeAuth = (options: MutationOptions<RefreshedDTO>) =>
+  useMutation({
+    mutationKey: ['removeAuth'],
+    mutationFn: () => _fetch('/auth', { method: 'DELETE' }),
+    ...options,
+  });
+
+export default removeAuth;


### PR DESCRIPTION
DESC
----
- 로그아웃에 사용할 frontend API 생성

NOTE
----
- cookie를 테스트할 방법이 없어 API의 테스트코드를 작성하지 않음