### PR TITLE
feat : fetch에서 사용하는 method를 enum으로 대체

### DIFF
--- a/packages/frontend/src/api/auth/confirm.ts
+++ b/packages/frontend/src/api/auth/confirm.ts
@@ -1,12 +1,13 @@
 import { ConfirmAuthDTO } from '@my-task/common';
 import { useMutation } from '@tanstack/react-query';
+import { HttpMethod } from '~/constants';
 import { MutationOptions } from '~/types';
 import _fetch from '../core';
 
 const confirmAuth = (options: MutationOptions<{ email: string }, ConfirmAuthDTO>) =>
   useMutation({
     mutationKey: ['confirmAuth'],
-    mutationFn: (body) => _fetch('/auth/confirm', { method: 'POST', body }),
+    mutationFn: (body) => _fetch('/auth/confirm', { method: HttpMethod.POST, body }),
     ...options,
   });
 

--- a/packages/frontend/src/api/auth/refresh.ts
+++ b/packages/frontend/src/api/auth/refresh.ts
@@ -6,7 +6,7 @@ import _fetch from '../core';
 const refreshAuth = (option: QueryOptions<RefreshedDTO>) =>
   useQuery({
     queryKey: ['refreshAuth'],
-    queryFn: () => _fetch('/auth', { method: 'GET' }),
+    queryFn: () => _fetch('/auth'),
     ...option,
   });
 

--- a/packages/frontend/src/api/auth/remove.ts
+++ b/packages/frontend/src/api/auth/remove.ts
@@ -1,12 +1,13 @@
 import { RefreshedDTO } from '@my-task/common';
 import { useMutation } from '@tanstack/react-query';
+import { HttpMethod } from '~/constants';
 import { MutationOptions } from '~/types';
 import _fetch from '../core';
 
 const removeAuth = (options: MutationOptions<RefreshedDTO>) =>
   useMutation({
     mutationKey: ['removeAuth'],
-    mutationFn: () => _fetch('/auth', { method: 'DELETE' }),
+    mutationFn: () => _fetch('/auth', { method: HttpMethod.DELETE }),
     ...options,
   });
 

--- a/packages/frontend/src/api/auth/request.ts
+++ b/packages/frontend/src/api/auth/request.ts
@@ -1,12 +1,13 @@
 import { RequestAuthDTO } from '@my-task/common';
 import { useMutation } from '@tanstack/react-query';
+import { HttpMethod } from '~/constants';
 import { MutationOptions } from '~/types';
 import _fetch from '../core';
 
 const requestAuth = (options: MutationOptions<RequestAuthDTO, RequestAuthDTO>) =>
   useMutation({
     mutationKey: ['requestAuth'],
-    mutationFn: (body) => _fetch('/auth/request', { method: 'POST', body }),
+    mutationFn: (body) => _fetch('/auth/request', { method: HttpMethod.POST, body }),
     ...options,
   });
 

--- a/packages/frontend/src/api/core/index.test.ts
+++ b/packages/frontend/src/api/core/index.test.ts
@@ -29,11 +29,6 @@ describe('_fetch', () => {
       expect(async () => _fetch(path)).rejects.toThrow();
     });
 
-    it('invalid method', () => {
-      const path = '/';
-      expect(async () => _fetch(path, { method: 'WRONG_METHOD' })).rejects.toThrow();
-    });
-
     it('error thrown in server', () => {
       const path = '/error';
       expect(async () => _fetch(path)).rejects.toThrow();

--- a/packages/frontend/src/api/core/index.ts
+++ b/packages/frontend/src/api/core/index.ts
@@ -1,8 +1,9 @@
 import { JsonObject, mergeObjects } from '@my-task/common';
-import { BE_ORIGIN, DEFAULT_FETCH_OPTIONS } from '~/constants';
+import { BE_ORIGIN, DEFAULT_FETCH_OPTIONS, HttpMethod } from '~/constants';
 
 type RequestOption<BodyType extends JsonObject> = Partial<Pick<JsonObject, keyof RequestInit>> & {
   body?: BodyType;
+  method?: (typeof HttpMethod)[keyof typeof HttpMethod];
 };
 
 type BodyObject = { body: string } | {};

--- a/packages/frontend/src/constants/defaultFetchOptions.ts
+++ b/packages/frontend/src/constants/defaultFetchOptions.ts
@@ -1,7 +1,8 @@
 import { JsonObject } from '@my-task/common';
+import HttpMethod from './HttpMethod';
 
 const DEFAULT_FETCH_OPTIONS: Partial<Pick<JsonObject, keyof RequestInit>> = {
-  method: 'GET',
+  method: HttpMethod.GET,
   headers: { 'Content-Type': 'application/json' },
   credentials: 'include',
 };


### PR DESCRIPTION
DESC
----
- fetch에서 사용하는 method를 단순 string에서 HttpMethod enum으로 대체

NOTE
----
- fetch의 method를 테스트하던 테스트 코드 제거