### PR TITLE
refact : route를 테스트할 때 사용하는 render를 wrapping

### DIFF
--- a/packages/frontend/src/mock/index.ts
+++ b/packages/frontend/src/mock/index.ts
@@ -1,3 +1,5 @@
+import render from './render';
 export * from './constants';
 export * from './handlers';
 export * from './server';
+export { render };

--- a/packages/frontend/src/mock/render.tsx
+++ b/packages/frontend/src/mock/render.tsx
@@ -1,0 +1,30 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+
+const renderScreen = (ui: React.ReactElement) => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+    logger: {
+      log: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+  });
+
+  const element = (
+    <QueryClientProvider client={client}>
+      <RecoilRoot>{ui}</RecoilRoot>
+    </QueryClientProvider>
+  );
+  const screen = render(element);
+
+  return { screen, element, client };
+};
+
+export default renderScreen;

--- a/packages/frontend/src/routes/Auth/confirm.test.tsx
+++ b/packages/frontend/src/routes/Auth/confirm.test.tsx
@@ -1,27 +1,14 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { RenderResult, render, waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { RenderResult, waitFor } from '@testing-library/react';
 import { RouteObject, RouterProvider, createMemoryRouter } from 'react-router-dom';
-import { RecoilRoot } from 'recoil';
 import { describe, expect, it } from 'vitest';
 import { BE_ORIGIN } from '~/constants';
-import { server, validEmail, validUUID } from '~/mock';
+import { render, server, validEmail, validUUID } from '~/mock';
 import authRouteObject from '.';
 
 describe('Auth - Confirm', () => {
   let screen: RenderResult;
-  let router: ReturnType<typeof createMemoryRouter>;
-  const testQueryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-    logger: {
-      log: () => {},
-      warn: console.warn,
-      error: () => {},
-    },
-  });
+  let client: QueryClient;
 
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
   // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
@@ -29,24 +16,17 @@ describe('Auth - Confirm', () => {
   afterEach(() => server.resetHandlers());
   afterAll(() => server.close());
 
-  const renderWithRouter = (path: string) => {
-    const rootRouteObject: RouteObject = { path: '', element: <div>redirected!</div> };
-    router = createMemoryRouter([rootRouteObject, authRouteObject], {
-      initialEntries: [path],
-    });
-    return render(
-      <QueryClientProvider client={testQueryClient}>
-        <RecoilRoot>
-          <RouterProvider router={router} />
-        </RecoilRoot>
-      </QueryClientProvider>,
-    );
-  };
-
   describe('should work', () => {
     beforeEach(() => {
-      screen = renderWithRouter(`/auth/${validUUID}`);
+      const rootRouteObject: RouteObject = { path: '', element: <div>redirected!</div> };
+      const router = createMemoryRouter([rootRouteObject, authRouteObject], {
+        initialEntries: [`/auth/${validUUID}`],
+      });
+      const renderResult = render(<RouterProvider router={router} />);
+      screen = renderResult.screen;
+      client = renderResult.client;
     });
+    afterEach(() => client.clear());
 
     it('when loading', async () => {
       const text = screen.getByText('Loading...');
@@ -54,7 +34,7 @@ describe('Auth - Confirm', () => {
     });
 
     it('when success', async () => {
-      await waitFor(() => expect(testQueryClient.isMutating()).toEqual(0));
+      await waitFor(() => expect(client.isMutating()).toEqual(0));
 
       const text = screen.getByText(`Welcome, ${validEmail}!`);
       expect(text).toBeDefined();

--- a/packages/frontend/src/routes/Auth/error.test.tsx
+++ b/packages/frontend/src/routes/Auth/error.test.tsx
@@ -1,25 +1,14 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { RenderResult, render, waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { RenderResult, waitFor } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import { BE_ORIGIN } from '~/constants';
-import { invalidUUID, server } from '~/mock';
-import welcomeRouteObject from '.';
+import { invalidUUID, render, server } from '~/mock';
+import authRouteObject from '.';
 
 describe('Auth - Error', () => {
   let screen: RenderResult;
-  const testQueryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-    logger: {
-      log: () => {},
-      warn: () => {},
-      error: () => {},
-    },
-  });
+  let client: QueryClient;
 
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
   // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
@@ -27,29 +16,29 @@ describe('Auth - Error', () => {
   afterEach(() => server.resetHandlers());
   afterAll(() => server.close());
 
-  const renderWithRouter = (path: string) =>
-    render(
-      <QueryClientProvider client={testQueryClient}>
-        <RouterProvider
-          router={createMemoryRouter([welcomeRouteObject], {
-            initialEntries: [path],
-          })}
-        />
-      </QueryClientProvider>,
-    );
+  const renderWithRouter = (path: string) => {
+    const router = createMemoryRouter([authRouteObject], {
+      initialEntries: [path],
+    });
+    return render(<RouterProvider router={router} />);
+  };
 
   describe('should throw error when', () => {
     it('invalid string', async () => {
-      screen = renderWithRouter('/auth/@@@');
-      await waitFor(() => expect(testQueryClient.isMutating()).toEqual(0));
+      const renderResult = renderWithRouter('/auth/@@@');
+      screen = renderResult.screen;
+      client = renderResult.client;
+      await waitFor(() => expect(client.isMutating()).toEqual(0));
 
       const text = screen.getByText('Parse Error : Given string cannot be parsed to UUID!');
       expect(text).toBeDefined();
     });
 
     it('invalid uuid', async () => {
-      screen = renderWithRouter(`/auth/${invalidUUID}`);
-      await waitFor(() => expect(testQueryClient.isMutating()).toEqual(0));
+      const renderResult = renderWithRouter(`/auth/${invalidUUID}`);
+      screen = renderResult.screen;
+      client = renderResult.client;
+      await waitFor(() => expect(client.isMutating()).toEqual(0));
 
       const text = screen.getByText('UUID cannot be found: Wrong DTO!');
       expect(text).toBeDefined();


### PR DESCRIPTION
DESC
----
- route를 테스트할 때 recoil을 사용할 수 있도록 `RecoilRoot`를 wrapping
- route를 테스트할 때 react-query을 사용할 수 있도록 `QueryClientProvider`를 wrapping
- react-query 접근 및 테스트를 위해 wrapper에서 screen과 client, render될 element를 return