### PR TITLE
feat : common에서 사용하는 zod schema의 폴더 구조를 정리

### DIFF
--- a/packages/common/src/env/host.ts
+++ b/packages/common/src/env/host.ts
@@ -1,9 +1,10 @@
 import { ZodIssueCode, z } from 'zod';
+import { STRING_RULE } from '../utils';
 
-const IP_RULE = z
-  .string()
-  .ip()
-  .refine((ip) => ip.split('.')[0] !== '0', ZodIssueCode.invalid_string);
+const IP_RULE = STRING_RULE.ip().refine(
+  (ip) => ip.split('.')[0] !== '0',
+  ZodIssueCode.invalid_string,
+);
 const LOCALHOST_RULE = z.literal('localhost');
 const DOCKERHOST_RULE = z.literal('host.docker.internal');
 

--- a/packages/common/src/env/index.ts
+++ b/packages/common/src/env/index.ts
@@ -1,6 +1,5 @@
 import HOST_RULE from './host';
-import NUMERIC_STRING_RULE from './numericString';
 import PORT_RULE from './port';
 import SYSTEM_PORT_RULE from './systemPort';
 import USER_PORT_RULE from './userPort';
-export { HOST_RULE, NUMERIC_STRING_RULE, PORT_RULE, SYSTEM_PORT_RULE, USER_PORT_RULE };
+export { HOST_RULE, PORT_RULE, SYSTEM_PORT_RULE, USER_PORT_RULE };

--- a/packages/common/src/env/numericString.ts
+++ b/packages/common/src/env/numericString.ts
@@ -1,7 +1,0 @@
-import { ZodIssueCode, z } from 'zod';
-
-const NUMERIC_STRING_RULE = z
-  .string()
-  .transform(Number)
-  .refine((val) => !isNaN(val), ZodIssueCode.invalid_string);
-export default NUMERIC_STRING_RULE;

--- a/packages/common/src/env/port.ts
+++ b/packages/common/src/env/port.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import NUMERIC_STRING_RULE from './numericString';
+import { NUMERIC_STRING_RULE } from '../utils';
 
 const PORT_MIN = 0;
 const PORT_MAX = 65535;

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,3 +1,4 @@
 import dateAfter from './dateAfter';
 import mergeObjects from './mergeObjects';
+export * from './zod';
 export { dateAfter, mergeObjects };

--- a/packages/common/src/utils/zod/email.ts
+++ b/packages/common/src/utils/zod/email.ts
@@ -1,0 +1,3 @@
+import STRING_RULE from './string';
+const EMAIL_RULE = STRING_RULE.email();
+export default EMAIL_RULE;

--- a/packages/common/src/utils/zod/index.ts
+++ b/packages/common/src/utils/zod/index.ts
@@ -1,0 +1,5 @@
+import EMAIL_RULE from './email';
+import NUMERIC_STRING_RULE from './numericString';
+import STRING_RULE from './string';
+import UUID_RULE from './uuid';
+export { EMAIL_RULE, NUMERIC_STRING_RULE, STRING_RULE, UUID_RULE };

--- a/packages/common/src/utils/zod/numericString.test.ts
+++ b/packages/common/src/utils/zod/numericString.test.ts
@@ -4,7 +4,7 @@ import NUMERIC_STRING_RULE from './numericString';
 
 describe('numericString', () => {
   describe('should work with', () => {
-    it('numeric tring', () => {
+    it('numeric string', () => {
       const before = '300';
       const after = NUMERIC_STRING_RULE.parse(before);
       expect(after).equal(parseInt(before));

--- a/packages/common/src/utils/zod/numericString.ts
+++ b/packages/common/src/utils/zod/numericString.ts
@@ -1,0 +1,8 @@
+import { ZodIssueCode } from 'zod';
+import STRING_RULE from './string';
+
+const NUMERIC_STRING_RULE = STRING_RULE.transform(Number).refine(
+  (val) => !isNaN(val),
+  ZodIssueCode.invalid_string,
+);
+export default NUMERIC_STRING_RULE;

--- a/packages/common/src/utils/zod/string.test.ts
+++ b/packages/common/src/utils/zod/string.test.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import STRING_RULE from './string';
+
+describe('string', () => {
+  describe('should work with', () => {
+    it('string', () => {
+      const before = 'string';
+      const after = STRING_RULE.parse(before);
+      expect(after).equal(before);
+    });
+  });
+
+  describe('should throw error when', () => {
+    describe('type', () => {
+      it('number', () => {
+        const before = 123;
+        expect(() => STRING_RULE.parse(before)).throw();
+      });
+
+      it('boolean', () => {
+        const before = true;
+        expect(() => STRING_RULE.parse(before)).throw();
+      });
+
+      it('object', () => {
+        const before = { foo: 'bar' };
+        expect(() => STRING_RULE.parse(before)).throw();
+      });
+
+      it('undefined', () => {
+        const before = undefined;
+        expect(() => STRING_RULE.parse(before)).throw();
+      });
+
+      it('null', () => {
+        const before = null;
+        expect(() => STRING_RULE.parse(before)).throw();
+      });
+
+      it('function', () => {
+        const before = () => {};
+        expect(() => STRING_RULE.parse(before)).throw();
+      });
+    });
+
+    describe('value', () => {
+      it('empty string', () => {
+        const before = '';
+        expect(() => STRING_RULE.parse(before)).throw();
+      });
+    });
+  });
+});

--- a/packages/common/src/utils/zod/string.ts
+++ b/packages/common/src/utils/zod/string.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+const STRING_RULE = z.string().min(1);
+export default STRING_RULE;

--- a/packages/common/src/utils/zod/uuid.ts
+++ b/packages/common/src/utils/zod/uuid.ts
@@ -1,0 +1,3 @@
+import STRING_RULE from './string';
+const UUID_RULE = STRING_RULE.uuid();
+export default UUID_RULE;


### PR DESCRIPTION
DESC
----
- 빈 문자열이 아닌 문자열의 schema인 STRING_RULE 정의
- NUMERIC_STRING_RULE을 STRING_RULE을 이용하도록 변경
- 자주 사용되는 문자열인 email, uuid의 schema를 별개 타입으로 설정