### PR TITLE
feat : findGroupByEmail의 User param을 email 문자열로 대체

### DIFF
--- a/packages/backend/src/mock/services/group.service.ts
+++ b/packages/backend/src/mock/services/group.service.ts
@@ -1,17 +1,17 @@
 import { Group, User } from '@my-task/common';
 
 const mockGroupService = async () => ({
-  groups: new Map<number, Group[]>(),
+  groups: new Map<string, Group[]>(),
+
   async createGroup(creator: User, name: string) {
-    const group: Group = {
-      id: Math.floor(Math.random() * 10),
-      name,
-    };
-    this.groups.set(creator.id, (this.groups.get(creator.id) || []).concat([group]));
+    const id = Math.floor(Math.random() * 10);
+    const group: Group = { id, name };
+    this.groups.set(creator.email, (this.groups.get(creator.email) || []).concat([group]));
     return group;
   },
-  async findGroupByMember(member: User) {
-    return this.groups.get(member.id) ?? [];
+
+  async findGroupByMember(email: string) {
+    return this.groups.get(email) ?? [];
   },
 });
 

--- a/packages/backend/src/modules/group/group.service.spec.ts
+++ b/packages/backend/src/modules/group/group.service.spec.ts
@@ -50,9 +50,9 @@ describe('GroupService', () => {
     });
   });
 
-  describe('findGroupByMember', () => {
+  describe('findGroupByEmail', () => {
     it('should work', async () => {
-      await expect(service.findGroupByMember(creator)).resolves.not.toThrow();
+      await expect(service.findGroupByEmail(creator.email)).resolves.not.toThrow();
     });
   });
 });


### PR DESCRIPTION
DESC
----
- group 조회 시 member를 email로 대체

NOTE
----
- 멤버 조회 실행 시 member 레코드를 가지고 있을 가능성은 없음