### PR TITLE
feat : group 목록 조회 시 사용자가 가입한 그룹의 총 개수를 결과에 포함

### DIFF
--- a/packages/backend/src/mock/services/group.service.ts
+++ b/packages/backend/src/mock/services/group.service.ts
@@ -32,8 +32,8 @@ const mockGroupService = async () => ({
     const start = (offset - 1) * limit;
 
     const arr = this.groups.get(email) ?? [];
-    const group = arr.slice(start, start + limit);
-    return { group };
+    const group = [...arr].slice(start, start + limit);
+    return { group, count: arr.length };
   },
 });
 

--- a/packages/backend/src/modules/group/group.controller.spec.ts
+++ b/packages/backend/src/modules/group/group.controller.spec.ts
@@ -55,6 +55,8 @@ describe('GroupController', () => {
         expect(result).toBeDefined();
         expect(result).toHaveProperty('group');
         expect(result.group.length).toEqual(3);
+        expect(result).toHaveProperty('count');
+        expect(result.count).toEqual(3);
       });
 
       it('with page', async () => {
@@ -62,6 +64,8 @@ describe('GroupController', () => {
         expect(result).toBeDefined();
         expect(result).toHaveProperty('group');
         expect(result.group.length).toEqual(0);
+        expect(result).toHaveProperty('count');
+        expect(result.count).toEqual(3);
       });
     });
   });

--- a/packages/backend/src/modules/group/group.service.spec.ts
+++ b/packages/backend/src/modules/group/group.service.spec.ts
@@ -70,7 +70,7 @@ describe('GroupService', () => {
   });
 
   describe('findGroupByEmail', () => {
-    describe('should work with', () => {
+    describe('should work', () => {
       beforeEach(async () => {
         // Promise.all causes 'open handles' problem
         await service.createGroup(creator, 'test1');
@@ -78,11 +78,13 @@ describe('GroupService', () => {
         await service.createGroup(creator, 'test3');
       });
 
-      it('no page info', async () => {
+      it('with no page info', async () => {
         const result = await service.findGroupByEmail(creator.email);
         expect(result).toBeDefined();
         expect(result).toHaveProperty('group');
         expect(result.group.length).toEqual(3);
+        expect(result).toHaveProperty('count');
+        expect(result.count).toEqual(3);
       });
 
       it('invalid email', async () => {
@@ -91,18 +93,22 @@ describe('GroupService', () => {
       });
 
       it('with offset, without limit', async () => {
-        const { group } = await service.findGroupByEmail(creator.email, { offset: 2 });
+        const { group, count } = await service.findGroupByEmail(creator.email, { offset: 2 });
         expect(group.length).toEqual(0);
+        expect(count).toEqual(3);
       });
 
       it('without offset, with limit', async () => {
-        const { group } = await service.findGroupByEmail(creator.email, { limit: 2 });
+        const { group, count } = await service.findGroupByEmail(creator.email, { limit: 2 });
         expect(group.length).toEqual(2);
+        expect(count).toEqual(3);
       });
 
-      it('without offset and limit', async () => {
-        const { group } = await service.findGroupByEmail(creator.email, { offset: 2, limit: 2 });
+      it('with offset and limit', async () => {
+        const pageInfo = { offset: 2, limit: 2 };
+        const { group, count } = await service.findGroupByEmail(creator.email, pageInfo);
         expect(group.length).toEqual(1);
+        expect(count).toEqual(3);
       });
     });
   });

--- a/packages/common/src/dto/group/list.dto.ts
+++ b/packages/common/src/dto/group/list.dto.ts
@@ -2,6 +2,7 @@ import { Group } from '../../database';
 
 type GroupListDTO = {
   group: Pick<Group, 'id' | 'name'>[];
+  count: number;
 };
 
 export type { GroupListDTO };

--- a/packages/frontend/src/api/group/list.test.tsx
+++ b/packages/frontend/src/api/group/list.test.tsx
@@ -34,6 +34,8 @@ describe('fetchGroupList', () => {
     expect(data).toBeDefined();
     expectTypeOf(data as any).toHaveProperty('group');
     expect(data?.group.length).toEqual(10);
+    expectTypeOf(data as any).toHaveProperty('count');
+    expect(data?.count).toEqual(13);
   });
 
   it('should work with page query', async () => {
@@ -47,8 +49,9 @@ describe('fetchGroupList', () => {
 
     await waitFor(() => expect(renderedHook.result.current.isLoading).toEqual(false));
 
-    const { group } = renderedHook.result.current.data as GroupListDTO;
+    const { group, count } = renderedHook.result.current.data as GroupListDTO;
     expect(group).toBeDefined();
     expect(group.length).toEqual(3);
+    expect(count).toEqual(13);
   });
 });

--- a/packages/frontend/src/mock/handlers/group.ts
+++ b/packages/frontend/src/mock/handlers/group.ts
@@ -12,12 +12,13 @@ const groupHandlers = [
     const page = parseInt(params.get('page') ?? '1');
     const limit = parseInt(params.get('limit') ?? '10');
 
-    const group: GroupListDTO['group'] = new Array(13)
+    const groupArr: GroupListDTO['group'] = new Array(13)
       .fill(0)
-      .map((_, i) => ({ id: i, name: `name${i}` }))
-      .slice((page - 1) * limit, page * limit);
+      .map((_, i) => ({ id: i, name: `name${i}` }));
 
-    return res(ctx.status(200), ctx.json({ group }));
+    const group = [...groupArr].slice((page - 1) * limit, page * limit);
+
+    return res(ctx.status(200), ctx.json({ group, count: groupArr.length }));
   }),
 ];
 


### PR DESCRIPTION
DESC
----
- page 조건에 맞는 그룹 목록 외에도 소속된 전체 그룹의 수를 같이 반환

NOTE
----
- 전체 그룹의 수를 이용해 페이징 컴포넌트를 생성할 예정