### PR TITLE
feat : 특정 그룹의 멤버 목록을 가져오는 기능 생성

### DIFF
--- a/packages/common/src/dto/index.ts
+++ b/packages/common/src/dto/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
 export * from './group';
+export * from './member';

--- a/packages/common/src/dto/member/index.ts
+++ b/packages/common/src/dto/member/index.ts
@@ -1,0 +1,2 @@
+import { MemberListDTO } from './list.dto';
+export type { MemberListDTO };

--- a/packages/common/src/dto/member/list.dto.ts
+++ b/packages/common/src/dto/member/list.dto.ts
@@ -1,0 +1,8 @@
+import { Member, User } from '../../database';
+
+type MemberListDTO = {
+  member: Pick<User & Member, 'id' | 'email' | 'name' | 'isManager'>[];
+  count: number;
+};
+
+export type { MemberListDTO };


### PR DESCRIPTION
DESC
----
- 그룹 id를 이용해 특정 그룹의 멤버 목록을 가져오는 기능 생성
- 관리자 여부에 따라, 관리자 여부가 같다면 가입 순서에 따라 멤버를 정렬