### PR TITLE
feat : Group Detail 페이지 생성

### DIFF
--- a/packages/frontend/src/components/Group/Invite/index.test.tsx
+++ b/packages/frontend/src/components/Group/Invite/index.test.tsx
@@ -1,0 +1,70 @@
+import { QueryClient } from '@tanstack/react-query';
+import { RenderResult, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, vi } from 'vitest';
+import { BE_ORIGIN } from '~/constants';
+import { render, server } from '~/mock';
+import GroupInvite from '.';
+
+describe('GroupInvite', () => {
+  let screen: RenderResult;
+  let client: QueryClient;
+  let addButton: HTMLElement | null;
+  let emailInput: HTMLElement | null;
+  let submitButton: HTMLElement | null;
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
+  beforeEach(() => location.replace(BE_ORIGIN));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  beforeEach(() => {
+    const renderResult = render(
+      <MemoryRouter>
+        <GroupInvite groupId={123} />
+      </MemoryRouter>,
+    );
+    screen = renderResult.screen;
+    client = renderResult.client;
+
+    addButton = screen.queryByText('Invite New Member');
+    emailInput = screen.queryByLabelText('User E-Mail:');
+    submitButton = screen.queryByText('Invite');
+  });
+
+  it('should render', () => {
+    expect(screen).toBeDefined();
+    expect(client).toBeDefined();
+  });
+
+  it('should have expected elements', () => {
+    expect(addButton).not.toBeNull();
+    expect(emailInput).not.toBeNull();
+    expect(submitButton).not.toBeNull();
+  });
+
+  it('should show modal', async () => {
+    const showModalFunc = vi.fn();
+    HTMLDialogElement.prototype.showModal = showModalFunc;
+
+    fireEvent.click(addButton as HTMLButtonElement);
+    expect(showModalFunc).toBeCalled();
+  });
+
+  describe('event', () => {
+    it('should fire event with email', async () => {
+      fireEvent.change(emailInput as HTMLInputElement, 'test@email.com');
+      fireEvent.click(submitButton as HTMLButtonElement);
+      // 서버 실행 후 테스트한 경우 제대로 작동함
+      // expect(client.isMutating()).toEqual(1);
+      await waitFor(() => expect(client.isMutating()).toEqual(0));
+    });
+
+    it('should not fire event with non-email', async () => {
+      fireEvent.change(emailInput as HTMLInputElement, 'invalid@email');
+      fireEvent.click(submitButton as HTMLButtonElement);
+      expect(client.isMutating()).toEqual(0);
+    });
+  });
+});

--- a/packages/frontend/src/components/Group/Invite/index.tsx
+++ b/packages/frontend/src/components/Group/Invite/index.tsx
@@ -1,0 +1,60 @@
+import { FormEventHandler, MouseEventHandler, useRef } from 'react';
+import { inviteMember } from '~/api';
+import { Modal } from '~/components';
+
+type Props = {
+  groupId: number;
+};
+
+const GroupInvite = (props: Props) => {
+  const { groupId } = props;
+  const modalRef = useRef<HTMLDialogElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const mutation = inviteMember({});
+
+  const isDisabled = mutation.isLoading;
+
+  const getElements = () => {
+    const modal = modalRef.current;
+    const input = inputRef.current;
+
+    return { modal, input };
+  };
+
+  const onClick: MouseEventHandler = () => {
+    const { modal } = getElements();
+    if (!modal) return;
+
+    modal.showModal();
+  };
+
+  const onSubmit: FormEventHandler = (e) => {
+    e.preventDefault();
+
+    const { modal, input } = getElements();
+    if (!input) return;
+
+    const email = input.value;
+    mutation.mutate({ groupId, email });
+    if (modal) modal.close();
+  };
+
+  return (
+    <>
+      <button onClick={onClick}>
+        <span>Invite New Member</span>
+      </button>
+      <Modal title="Invite Member" ref={modalRef}>
+        <form onSubmit={onSubmit}>
+          <label htmlFor="member-email">User E-Mail: </label>
+          <input id="member-email" type="email" ref={inputRef} required aria-required />
+          <button type="submit" disabled={isDisabled} aria-disabled={isDisabled}>
+            Invite
+          </button>
+        </form>
+      </Modal>
+    </>
+  );
+};
+
+export default GroupInvite;

--- a/packages/frontend/src/components/Group/index.ts
+++ b/packages/frontend/src/components/Group/index.ts
@@ -1,2 +1,3 @@
 import GroupAdd from './Add';
-export { GroupAdd };
+import GroupInvite from './Invite';
+export { GroupAdd, GroupInvite };

--- a/packages/frontend/src/routes/Group/Detail/index.tsx
+++ b/packages/frontend/src/routes/Group/Detail/index.tsx
@@ -1,0 +1,18 @@
+import { NUMERIC_STRING_RULE } from '@my-task/common';
+import { useParams } from 'react-router-dom';
+import { GroupInvite } from '~/components';
+
+const GroupDetail = () => {
+  const { id } = useParams();
+  const groupId = NUMERIC_STRING_RULE.parse(id);
+
+  return (
+    <div>
+      <h3>Group Name</h3>
+      <GroupInvite groupId={groupId} />
+      <ul></ul>
+    </div>
+  );
+};
+
+export default GroupDetail;

--- a/packages/frontend/src/routes/Group/List/index.tsx
+++ b/packages/frontend/src/routes/Group/List/index.tsx
@@ -1,6 +1,6 @@
 import { Group } from '@my-task/common';
 import { useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { fetchGroupList } from '~/api';
 import { GroupAdd } from '~/components';
 import styles from './styles.module.scss';
@@ -39,9 +39,11 @@ const GroupList = () => {
         ) : (
           <div className={styles.list}>
             {group.map(({ id, name }) => (
-              <div key={id} className={styles.item}>
-                <span className={styles.text}>{name}</span>
-              </div>
+              <Link to={`/group/${id}`}>
+                <div key={id} className={styles.item}>
+                  <span className={styles.text}>{name}</span>
+                </div>
+              </Link>
             ))}
           </div>
         )}

--- a/packages/frontend/src/routes/Group/index.tsx
+++ b/packages/frontend/src/routes/Group/index.tsx
@@ -1,9 +1,19 @@
 import { RouteObject } from 'react-router-dom';
+import GroupDetail from './Detail';
 import GroupList from './List';
 
 const groupRouteObject: RouteObject = {
   path: 'group',
-  element: <GroupList />,
+  children: [
+    {
+      path: '',
+      element: <GroupList />,
+    },
+    {
+      path: ':id',
+      element: <GroupDetail />,
+    },
+  ],
 };
 
 export default groupRouteObject;


### PR DESCRIPTION
DESC
----
- Group Detail route 생성
  - Invite modal을 가진 버튼 생성 TEST
----
1. 백엔드 및 프론트엔드 실행
2. 두 개 이상의 User 생성
3. 특정 사용자의 group 목록 페이지로 이동
4. 자동으로 생성된 group 아이템을 눌러 group detail 페이지로 이동
5. invite 버튼을 눌러 다른 사용자를 초대
6. 초대된 각 사용자의 group 목록 페이지를 확인해 새 그룹에 초대되었는지 확인

NOTE
----
- group invite 버튼 테스트가 동작하지 않음