### PR TITLE
test : cacheService를 mock

### DIFF
--- a/packages/backend/src/mock/modules/auth.module.ts
+++ b/packages/backend/src/mock/modules/auth.module.ts
@@ -2,6 +2,7 @@ import { Provider } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import {
   MockAuthService,
+  MockCacheService,
   MockCookieService,
   MockEmailService,
   MockGroupService,
@@ -19,6 +20,7 @@ import mockJwtModule from './jwt.module';
 
 type Props = {
   authService?: MockAuthService;
+  cacheService?: MockCacheService;
   cookieService?: MockCookieService;
   databaseService?: DatabaseService;
   emailService?: MockEmailService;
@@ -27,12 +29,13 @@ type Props = {
 
 const mockAuthModule = async ({
   authService,
+  cacheService,
   cookieService,
   databaseService,
   emailService,
   groupService,
 }: Props) => {
-  const providers: Provider[] = [CookieService, CacheService, JwtStrategy];
+  const providers: Provider[] = [CacheService, CookieService, JwtStrategy];
 
   if (authService || databaseService) providers.push(AuthService);
   if (cookieService) providers.push(CookieService);
@@ -50,6 +53,7 @@ const mockAuthModule = async ({
   });
 
   if (authService) moduleFactory.overrideProvider(AuthService).useValue(authService);
+  if (cacheService) moduleFactory.overrideProvider(CacheService).useValue(cacheService);
   if (cookieService) moduleFactory.overrideProvider(CookieService).useValue(cookieService);
   if (databaseService) moduleFactory.overrideProvider(DatabaseService).useValue(databaseService);
   if (emailService) moduleFactory.overrideProvider(EmailService).useValue(emailService);

--- a/packages/backend/src/mock/services/cache.service.ts
+++ b/packages/backend/src/mock/services/cache.service.ts
@@ -1,0 +1,58 @@
+const mockCacheService = async () => {
+  const setStores = new Map<string, Set<string>>();
+  const mapStores = new Map<string, Map<string, string>>();
+  const timeoutArray: NodeJS.Timeout[] = [];
+
+  return {
+    toSet: (tableName: string) => {
+      setStores.set(tableName, new Set());
+
+      return {
+        set: async (value: string, expiresAt?: Date) => {
+          const store = setStores.get(tableName) as Set<string>;
+          store.add(value);
+
+          if (expiresAt) {
+            const ETA = expiresAt.getTime() - new Date().getTime();
+            const timeout = setTimeout(() => store.delete(value), ETA);
+            timeoutArray.push(timeout);
+          }
+
+          return 1;
+        },
+        get: async () => setStores.get(tableName) ?? new Set<string>(),
+        has: async (value: string) => setStores.get(tableName)?.has(value),
+        del: async (value: string) => setStores.get(tableName)?.delete(value),
+      };
+    },
+
+    toHash: (tableName: string) => {
+      mapStores.set(tableName, new Map());
+
+      return {
+        set: async (field: string, value: string, expiresAt?: Date) => {
+          const store = mapStores.get(tableName) as Map<string, string>;
+          store.set(field, value);
+          if (expiresAt) {
+            const ETA = expiresAt.getTime() - new Date().getTime();
+            const timeout = setTimeout(() => store.delete(value), ETA);
+            timeoutArray.push(timeout);
+          }
+          return 1;
+        },
+        get: async (field: string) => mapStores.get(tableName)?.get(field) || null,
+        has: async (field: string) => mapStores.get(tableName)?.has(field) || false,
+        del: async (field: string) => (mapStores.get(tableName)?.delete(field) ? 1 : 0),
+      };
+    },
+
+    onModuleDestroy: async () => {
+      timeoutArray.forEach(clearTimeout);
+    },
+  };
+};
+
+type MockCacheService = Awaited<ReturnType<typeof mockCacheService>>;
+
+export { mockCacheService };
+export type { MockCacheService };

--- a/packages/backend/src/mock/services/index.ts
+++ b/packages/backend/src/mock/services/index.ts
@@ -1,4 +1,5 @@
 export * from './auth.service';
+export * from './cache.service';
 export * from './cookie.service';
 export * from './email.service';
 export * from './group.service';

--- a/packages/backend/src/modules/auth/auth.service.spec.ts
+++ b/packages/backend/src/modules/auth/auth.service.spec.ts
@@ -2,7 +2,15 @@ import { RequestAuthDTO } from '@my-task/common';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import { ACCESS_TOKEN, CACHE_TABLE_NAME, REFRESH_TOKEN } from '~/constants';
-import { mockAuthModule, mockDatabaseModule, mockGroupService, validEmail } from '~/mock';
+import {
+  MockCacheService,
+  MockGroupService,
+  mockAuthModule,
+  mockCacheService,
+  mockDatabaseModule,
+  mockGroupService,
+  validEmail,
+} from '~/mock';
 import { AuthService } from '~/modules/auth/auth.service';
 import { CacheService } from '~/modules/cache/cache.service';
 import { DatabaseService } from '~/modules/database/database.service';
@@ -10,7 +18,7 @@ import { DatabaseService } from '~/modules/database/database.service';
 describe('AuthService', () => {
   let service: AuthService;
   let databaseService: DatabaseService;
-  let cacheService: CacheService;
+  let cacheService: MockCacheService;
 
   let email: string;
   let uuid: string;
@@ -23,13 +31,12 @@ describe('AuthService', () => {
     databaseService = databaseModule.get<DatabaseService>(DatabaseService);
     await databaseService.onModuleInit();
 
-    const groupService = await mockGroupService();
+    let groupService: MockGroupService;
+    [cacheService, groupService] = await Promise.all([mockCacheService(), mockGroupService()]);
 
-    const module = await mockAuthModule({ databaseService, groupService });
+    const module = await mockAuthModule({ databaseService, cacheService, groupService });
     service = module.get<AuthService>(AuthService);
-    cacheService = module.get<CacheService>(CacheService);
 
-    await cacheService.onModuleInit();
     RT2Email = cacheService.toHash(CACHE_TABLE_NAME.RT2Email);
   });
 

--- a/packages/backend/src/modules/auth/cookie.service.spec.ts
+++ b/packages/backend/src/modules/auth/cookie.service.spec.ts
@@ -5,22 +5,19 @@ import {
   REFRESH_TOKEN,
   REFRESH_TOKEN_LIFE_SPAN,
 } from '~/constants';
-import { mockAuthModule, validEmail } from '~/mock';
+import { MockCacheService, mockAuthModule, mockCacheService, validEmail } from '~/mock';
 import { CookieService } from '~/modules/auth/cookie.service';
-import { CacheService } from '~/modules/cache/cache.service';
 import { CookieSettings } from '~/types';
 
 describe('CookieService', () => {
   let service: CookieService;
+  let cacheService: MockCacheService;
   let email: string;
-  let cacheService: CacheService;
 
   beforeEach(async () => {
-    const module = await mockAuthModule({});
+    cacheService = await mockCacheService();
+    const module = await mockAuthModule({ cacheService });
     service = module.get<CookieService>(CookieService);
-    cacheService = module.get<CacheService>(CacheService);
-
-    await cacheService.onModuleInit();
 
     email = validEmail;
   });

--- a/packages/backend/src/modules/cache/cache.service.ts
+++ b/packages/backend/src/modules/cache/cache.service.ts
@@ -62,8 +62,8 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
         }
         return result;
       },
-      get: (field: string) => {
-        return this.redisClient.hGet(tableName, field);
+      get: async (field: string): Promise<string | null> => {
+        return this.redisClient.hGet(tableName, field).then((val) => val || null);
       },
       has: (field: string) => {
         return this.redisClient.hExists(tableName, field);


### PR DESCRIPTION
DESC
----
- 테스트 케이스가 많아지면서 테스트 도중 redis와의 연결로 인해 테스트가 실패하는 경우가 늘어남
- cacheService 테스트를 제외한 모든 테스트에서 cacheService를 mock한 값으로 변경

NOTE
----
toHash의 get의 return값을 `Promise<string | null>`로 명시