### PR TITLE
feat : member 목록 조회에 필요한 parameter 타입 정의

### DIFF
--- a/packages/frontend/src/types/dto/index.ts
+++ b/packages/frontend/src/types/dto/index.ts
@@ -1,1 +1,2 @@
 export * from './group';
+export * from './member';

--- a/packages/frontend/src/types/dto/member/index.ts
+++ b/packages/frontend/src/types/dto/member/index.ts
@@ -1,0 +1,2 @@
+import MemberListParam from './list';
+export type { MemberListParam };

--- a/packages/frontend/src/types/dto/member/list.ts
+++ b/packages/frontend/src/types/dto/member/list.ts
@@ -1,0 +1,6 @@
+type MemberListParam = {
+  groupId: number;
+  page?: number;
+};
+
+export default MemberListParam;


### PR DESCRIPTION
DESC
----
- member 목록 조회에 필요한 parameter 타입 정의
  - `groupId`
  - `page`

NOTE
----
- 페이지 당 member의 수인 `limit`은 부가기능으로 취급