### PR TITLE
feat : 그룹에 멤버 목록을 표시

### DIFF
--- a/packages/frontend/src/mock/handlers/group.ts
+++ b/packages/frontend/src/mock/handlers/group.ts
@@ -33,6 +33,15 @@ const groupHandlers = [
 
     return res(ctx.status(200), ctx.json({ id, name }));
   }),
+
+  rest.get(mockGroupDir('/:groupId'), async (req, res, ctx) => {
+    ctx.delay();
+
+    const { groupId } = req.params;
+    const name = `name${groupId}`;
+
+    return res(ctx.status(200), ctx.json({ id: groupId, name }));
+  }),
 ];
 
 export default groupHandlers;

--- a/packages/frontend/src/routes/Group/Detail/index.test.tsx
+++ b/packages/frontend/src/routes/Group/Detail/index.test.tsx
@@ -1,0 +1,70 @@
+import { QueryClient } from '@tanstack/react-query';
+import { RenderResult, fireEvent, waitFor } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { describe } from 'vitest';
+import { BE_ORIGIN } from '~/constants';
+import { render, server } from '~/mock';
+import groupRouteObject from '..';
+
+describe('GroupList', () => {
+  let screen: RenderResult;
+  let client: QueryClient;
+  let groupId: number;
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  // https://stackoverflow.com/questions/76046546/fetch-error-typeerror-err-invalid-url-invalid-url-for-requests-made-in-test
+  beforeEach(() => location.replace(BE_ORIGIN));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  const renderWithQuery = (groupId: number) => {
+    const router = createMemoryRouter([groupRouteObject], {
+      initialEntries: [`/group/${groupId}`],
+    });
+    const renderResult = render(<RouterProvider router={router} />);
+    screen = renderResult.screen;
+    client = renderResult.client;
+  };
+
+  describe('should work', () => {
+    beforeEach(() => {
+      groupId = 1;
+      renderWithQuery(groupId);
+    });
+
+    it('when loading', () => {
+      expect(screen.queryByText('loading...')).not.toBeNull();
+      expect(client.isFetching()).toEqual(1);
+      expect(client.isMutating()).toEqual(1);
+
+      const button = screen.queryByText('Load More User');
+      expect(button).not.toBeNull();
+    });
+
+    it('fetch completed', async () => {
+      await waitFor(() => expect(client.isFetching()).toEqual(0));
+      const heading = screen.queryByText(`name${groupId}`);
+
+      expect(heading).not.toBeNull();
+    });
+
+    it('mutation completed', async () => {
+      const memberRegExp = /^test\d+@email.com(\(manager\))?$/;
+      const filterMember = (itemlist: HTMLElement[]) =>
+        itemlist.filter((listitem) => memberRegExp.test(listitem.textContent ?? ''));
+
+      const button = screen.getByText('Load More User');
+      await waitFor(() => expect(client.isMutating()).toEqual(0));
+
+      const itemsBeforeClick = filterMember(screen.getAllByRole('listitem'));
+      expect(itemsBeforeClick.length).toEqual(30);
+
+      fireEvent.click(button);
+      expect(client.isMutating()).toEqual(1);
+      await waitFor(() => expect(client.isMutating()).toEqual(0));
+
+      const itemsAfterClick = filterMember(screen.getAllByRole('listitem'));
+      expect(itemsAfterClick.length).toBeGreaterThan(30);
+    });
+  });
+});

--- a/packages/frontend/src/routes/Group/Detail/index.tsx
+++ b/packages/frontend/src/routes/Group/Detail/index.tsx
@@ -1,23 +1,54 @@
-import { NUMERIC_STRING_RULE } from '@my-task/common';
+import { MemberListDTO, NUMERIC_STRING_RULE } from '@my-task/common';
+import { useCallback, useEffect, useReducer, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { fetchGroupInfo } from '~/api';
+import { fetchGroupInfo, fetchMemberList } from '~/api';
 import { GroupInvite } from '~/components';
 
+type MemberList = MemberListDTO['member'];
+
+const reducer = (state: MemberList, payload: MemberList) => state.concat(...payload);
+
 const GroupDetail = () => {
+  const [members, dispatch] = useReducer(reducer, []);
+  const nextPage = Math.ceil(members.length / 30) + 1;
+  const [maxPage, setMaxPage] = useState(1);
+
   const { id } = useParams();
   const groupId = NUMERIC_STRING_RULE.parse(id);
-  const query = fetchGroupInfo(groupId, {});
 
-  if (query.isLoading) return <div>loading...</div>;
+  const query = fetchGroupInfo(groupId, {});
+  const mutation = fetchMemberList({
+    onSuccess: (data) => {
+      if (data.member.length === 0) return;
+      dispatch(data.member);
+      setMaxPage(() => Math.ceil(data.count / 30));
+    },
+  });
+
+  const onClick = useCallback(() => mutation.mutate({ groupId, page: nextPage }), [members]);
+
+  useEffect(() => mutation.mutate({ groupId }), []);
+
   if (query.isError) throw new Error(query.error.errorMessage);
 
-  const group = query.data;
+  const group = !query.isLoading ? query.data : { id: -1, name: 'loading...' };
+  const isDisabled = mutation.isLoading || nextPage > maxPage;
 
   return (
     <div>
       <h3>{group.name}</h3>
       <GroupInvite groupId={groupId} />
-      <ul></ul>
+      <ul>
+        {members.map((member) => (
+          <li key={member.id}>
+            {member.email}
+            {member.isManager ? ' (manager)' : ''}
+          </li>
+        ))}
+      </ul>
+      <button onClick={onClick} disabled={isDisabled} aria-disabled={isDisabled}>
+        Load More User
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
DESC
----
- 특정 그룹 조회 페이지에 접속할 경우 사용자 목록을 표시

NOTE
----
- 각 멤버의 표시 이름을 설정 및 수정하는 기능이 추가될 경우 member name을 같이 표시할 예정