### PR TITLE
fix : member service를 group controller에서 제거

### DIFF
--- a/packages/backend/src/mock/modules/group.module.ts
+++ b/packages/backend/src/mock/modules/group.module.ts
@@ -1,6 +1,6 @@
 import { Provider } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { MockGroupService, MockMemberService } from '~/mock/services';
+import { MockGroupService } from '~/mock/services';
 import { DatabaseService } from '~/modules/database/database.service';
 import { GroupController } from '~/modules/group/group.controller';
 import { GroupService } from '~/modules/group/group.service';
@@ -9,17 +9,17 @@ import { MemberService } from '~/modules/member/member.service';
 type Props = {
   databaseService?: DatabaseService;
   groupService?: MockGroupService;
-  memberService?: MockMemberService;
 };
 
-const mockGroupModule = ({ databaseService, groupService, memberService }: Props) => {
+const mockGroupModule = ({ databaseService, groupService }: Props) => {
   const useController = !!groupService;
   const controllers = useController ? [GroupController] : [];
 
   const providers: Provider[] = [GroupService];
 
   if (databaseService) providers.push(DatabaseService);
-  if (memberService || !groupService) providers.push(MemberService);
+  // if (memberService || !groupService) providers.push(MemberService);
+  if (!groupService) providers.push(MemberService);
 
   const moduleFactory = Test.createTestingModule({
     providers,
@@ -28,7 +28,7 @@ const mockGroupModule = ({ databaseService, groupService, memberService }: Props
 
   if (databaseService) moduleFactory.overrideProvider(DatabaseService).useValue(databaseService);
   if (groupService) moduleFactory.overrideProvider(GroupService).useValue(groupService);
-  if (memberService) moduleFactory.overrideProvider(MemberService).useValue(memberService);
+  // if (memberService) moduleFactory.overrideProvider(MemberService).useValue(memberService);
 
   return moduleFactory.compile();
 };

--- a/packages/backend/src/modules/group/group.controller.spec.ts
+++ b/packages/backend/src/modules/group/group.controller.spec.ts
@@ -1,7 +1,6 @@
 import {
   MockGroupService,
   MockMemberService,
-  invalidEmail,
   mockGroupModule,
   mockGroupService,
   mockMemberService,
@@ -20,7 +19,7 @@ describe('GroupController', () => {
 
   beforeEach(async () => {
     [groupService, memberService] = await Promise.all([mockGroupService(), mockMemberService()]);
-    const module = await mockGroupModule({ groupService, memberService });
+    const module = await mockGroupModule({ groupService });
     controller = module.get<GroupController>(GroupController);
   });
 
@@ -90,21 +89,12 @@ describe('GroupController', () => {
       await memberService.createMemberByEmail(group.id, validEmail);
     });
 
+    // service 로직을 테스트하는 테스트 케이스는 넣지 않음
     it('should work', async () => {
-      const result = await controller.findGroupById(validEmail, group.id);
+      const result = await controller.findGroupById(group.id);
       expect(result).toBeDefined();
       expect(result).toHaveProperty('name');
       expect(result?.name).toEqual(name);
-    });
-
-    describe('should throw error when', () => {
-      it('invalid email', async () => {
-        await expect(controller.findGroupById(invalidEmail, group.id)).rejects.toThrow();
-      });
-
-      it('invalid group id', async () => {
-        await expect(controller.findGroupById(validEmail, -1)).rejects.toThrow();
-      });
     });
   });
 });

--- a/packages/backend/src/modules/group/group.controller.ts
+++ b/packages/backend/src/modules/group/group.controller.ts
@@ -8,20 +8,15 @@ import {
   ParseIntPipe,
   Post,
   Query,
-  UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
 import { Email } from '~/decorators';
 import { JwtGuard } from '~/guard';
-import { MemberService } from '~/modules/member/member.service';
 import { GroupService } from './group.service';
 
 @Controller('group')
 export class GroupController {
-  constructor(
-    private readonly groupService: GroupService,
-    private readonly memberService: MemberService,
-  ) {}
+  constructor(private readonly groupService: GroupService) {}
 
   @UseGuards(JwtGuard)
   @Post()
@@ -41,10 +36,7 @@ export class GroupController {
 
   @UseGuards(JwtGuard)
   @Get(':groupId')
-  async findGroupById(@Email() email: string, @Param('groupId', ParseIntPipe) groupId: number) {
-    const ifMember = await this.memberService.findIfUserIsMember(groupId, email);
-    if (!ifMember)
-      throw new UnauthorizedException(`User ${email} is not a member of Group #${groupId}`);
+  async findGroupById(@Param('groupId', ParseIntPipe) groupId: number) {
     return this.groupService.findGroupById(groupId);
   }
 }


### PR DESCRIPTION
DESC
----
- 단일 group 조회 시 member service의 기능을 사용하지 않도록 변경

NOTE
----
- 중복된 쿼리를 작성하는 것을 방지하기 위함