### PR TITLE
feat : findIfUserIsMember의 return값을 userId로 변경

### DIFF
--- a/packages/backend/src/modules/member/member.controller.ts
+++ b/packages/backend/src/modules/member/member.controller.ts
@@ -61,8 +61,8 @@ export class MemberController {
     @Param('groupId', ParseIntPipe) groupId: number,
     @Query('page') offset: number = 1,
   ) {
-    const ifMember = await this.memberService.findIfUserIsMember(groupId, email);
-    if (!ifMember)
+    const userId = await this.memberService.findIfUserIsMember(groupId, email);
+    if (userId < 0)
       throw new ForbiddenException(`User ${email} is not a member of Group #${groupId}`);
     return this.memberService.findMemberByGroupId(groupId, { offset });
   }

--- a/packages/backend/src/modules/member/member.service.spec.ts
+++ b/packages/backend/src/modules/member/member.service.spec.ts
@@ -166,25 +166,25 @@ describe('MemberService', () => {
       it('existing user and group', async () => {
         const result = await service.findIfUserIsMember(group.id, user.email);
         expect(result).toBeDefined();
-        expect(result).toEqual(true);
+        expect(result).toBeGreaterThan(0);
       });
 
       it('not existing user and existing group', async () => {
         const result = await service.findIfUserIsMember(group.id, invalidEmail);
         expect(result).toBeDefined();
-        expect(result).toEqual(false);
+        expect(result).toEqual(-1);
       });
 
       it('existing user and not existing group', async () => {
         const result = await service.findIfUserIsMember(-1, user.email);
         expect(result).toBeDefined();
-        expect(result).toEqual(false);
+        expect(result).toEqual(-1);
       });
 
       it('not existing user and group', async () => {
         const result = await service.findIfUserIsMember(-1, invalidEmail);
         expect(result).toBeDefined();
-        expect(result).toEqual(false);
+        expect(result).toEqual(-1);
       });
     });
   });

--- a/packages/backend/src/modules/member/member.service.ts
+++ b/packages/backend/src/modules/member/member.service.ts
@@ -62,14 +62,14 @@ export class MemberService {
 
   async findIfUserIsMember(groupId: number, email: string) {
     const result = await this.db
-      .select({ count: sql<string>`count(${members.id})` })
+      .select({ id: users.id })
       .from(members)
       .innerJoin(users, eq(members.userId, users.id))
       .where(
         and(eq(users.email, email), eq(members.groupId, groupId), eq(members.isDeleted, false)),
       );
 
-    return result.length === 1 && parseInt(result[0].count) > 0;
+    return result.length === 1 ? result[0].id : -1;
   }
 
   async findMemberByGroupId(


### PR DESCRIPTION
DESC
----
- user가 특정 group의 멤버라면 userId를, 아니라면 -1을 반환

NOTE
----
- 멤버인지 조회 후 멤버 정보를 활용할 경우를 대비