### PR TITLE
test : member를 isManager에 따라 정렬

### DIFF
--- a/packages/frontend/src/mock/handlers/member.ts
+++ b/packages/frontend/src/mock/handlers/member.ts
@@ -14,7 +14,16 @@ const memberHandlers = [
 
     const memberArr: MemberListDTO['member'] = new Array(33)
       .fill(0)
-      .map((_, i) => ({ id: i, name: `name${i}`, email: `test${i}@email.com`, isManager: false }));
+      .map((_, i) => ({
+        id: i,
+        name: `name${i}`,
+        email: `test${i}@email.com`,
+        isManager: i % 10 === 0,
+      }))
+      .sort((a, b) => {
+        if (a.isManager !== b.isManager) return a.isManager ? -1 : 1;
+        return a.id - b.id;
+      });
 
     const member = [...memberArr].slice((page - 1) * limit, page * limit);
 

--- a/packages/frontend/src/routes/Group/Detail/index.test.tsx
+++ b/packages/frontend/src/routes/Group/Detail/index.test.tsx
@@ -48,23 +48,25 @@ describe('GroupList', () => {
       expect(heading).not.toBeNull();
     });
 
-    it('mutation completed', async () => {
-      const memberRegExp = /^test\d+@email.com(\(manager\))?$/;
-      const filterMember = (itemlist: HTMLElement[]) =>
-        itemlist.filter((listitem) => memberRegExp.test(listitem.textContent ?? ''));
+    describe('mutation completed', async () => {
+      it('member list', async () => {
+        const memberRegExp = /^test\d+@email.com( \(manager\))?$/;
+        const filterMember = (itemlist: HTMLElement[]) =>
+          itemlist.filter((listitem) => memberRegExp.test(listitem.textContent ?? ''));
 
-      const button = screen.getByText('Load More User');
-      await waitFor(() => expect(client.isMutating()).toEqual(0));
+        const button = screen.getByText('Load More User');
+        await waitFor(() => expect(client.isMutating()).toEqual(0));
 
-      const itemsBeforeClick = filterMember(screen.getAllByRole('listitem'));
-      expect(itemsBeforeClick.length).toEqual(30);
+        const itemsBeforeClick = filterMember(screen.getAllByRole('listitem'));
+        expect(itemsBeforeClick.length).toEqual(30);
 
-      fireEvent.click(button);
-      expect(client.isMutating()).toEqual(1);
-      await waitFor(() => expect(client.isMutating()).toEqual(0));
+        fireEvent.click(button);
+        expect(client.isMutating()).toEqual(1);
+        await waitFor(() => expect(client.isMutating()).toEqual(0));
 
-      const itemsAfterClick = filterMember(screen.getAllByRole('listitem'));
-      expect(itemsAfterClick.length).toBeGreaterThan(30);
+        const itemsAfterClick = filterMember(screen.getAllByRole('listitem'));
+        expect(itemsAfterClick.length).toEqual(33);
+      });
     });
   });
 });


### PR DESCRIPTION
DESC
----
- group detail 페이지의 member를 manager 여부에 따라 정렬했을 때 제대로 동작하는지 테스트