### PR TITLE
chore : feature branch를 push할 때만 github action 동작

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: test
-on: push
+on:
+  push:
+    branches: feature/*
 jobs:
   common:
     runs-on: ubuntu-latest


### PR DESCRIPTION
DESC
----
- feature branch를 push할 때에만 github action이 동작하도록 변경

NOTE
----
- dependabot의 PR이 github action으로 인해 block되는 경우가 있음
- develop branch로 merge된 커밋은 github action으로 validate할 필요 없음