### PR TITLE
fix : getPageInfoSchema 사용 시 page와 limit을 형변환

### DIFF
--- a/packages/common/src/dto/query/pageInfo.test.ts
+++ b/packages/common/src/dto/query/pageInfo.test.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { getPageInfoSchema } from './pageInfo';
+
+describe('getPageInfoSchema', () => {
+  describe('should work when', () => {
+    it('with no parameter', () => {
+      expect(getPageInfoSchema().parse({})).deep.equal({ offset: 1, limit: 10 });
+    });
+
+    it('with page', () => {
+      expect(getPageInfoSchema().parse({ page: '2' })).deep.equal({ offset: 2, limit: 10 });
+    });
+
+    it('with limit', () => {
+      expect(getPageInfoSchema().parse({ limit: '30' })).deep.equal({ offset: 1, limit: 30 });
+    });
+
+    it('with page and limit', () => {
+      expect(getPageInfoSchema().parse({ page: '2', limit: '30' })).deep.equal({
+        offset: 2,
+        limit: 30,
+      });
+    });
+  });
+
+  describe('should throw error when', () => {
+    it('page or limit is defined and not numeric string', () => {
+      expect(() => getPageInfoSchema().parse({ page: 1 })).throw();
+      expect(() => getPageInfoSchema().parse({ page: true })).throw();
+      expect(() => getPageInfoSchema().parse({ page: null })).throw();
+      expect(() => getPageInfoSchema().parse({ page: 'null' })).throw();
+      expect(() => getPageInfoSchema().parse({ limit: 30 })).throw();
+      expect(() => getPageInfoSchema().parse({ limit: false })).throw();
+      expect(() => getPageInfoSchema().parse({ limit: null })).throw();
+      expect(() => getPageInfoSchema().parse({ limit: 'null' })).throw();
+    });
+  });
+});

--- a/packages/common/src/dto/query/pageInfo.ts
+++ b/packages/common/src/dto/query/pageInfo.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
+import { NUMERIC_STRING_RULE } from '../../utils';
 
 const getPageInfoSchema = (limit: number = 10) =>
   z
     .object({
-      page: z.number().min(1).default(1),
-      limit: z.number().min(1).default(limit),
+      page: NUMERIC_STRING_RULE.default('1'),
+      limit: NUMERIC_STRING_RULE.default(`${limit}`),
     })
     .transform((data) => ({
       offset: data.page,


### PR DESCRIPTION
DESC
----
- NestJS의 Query 데코레이터는 기본적으로 queryString의 value를 string으로 변형
- getPageInfoSchema의 z.number를 NUMERIC_STRING_RULE로 변경